### PR TITLE
switch to chef_gem resource

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,13 +17,9 @@
 # limitations under the License.
 #
 
-r = gem_package "right_aws" do
+chef_gem "right_aws" do
   version node['aws']['right_aws_version']
-  action :nothing
+  action :install
 end
 
-r.run_action(:install)
-
-require 'rubygems'
-Gem.clear_paths
 require 'right_aws'


### PR DESCRIPTION
Use the chef_gem resource instead of gem_package, to avoid the contortions required to use & install a gem prior to convergence.
