### PR TITLE
fix bug causing null volume_id attribute to be saved on node

### DIFF
--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -46,7 +46,7 @@ action :attach do
   else
     # attach the volume and register its id in the node data
     attach_volume(vol[:aws_id], instance_id, new_resource.device, new_resource.timeout)
-    node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = vol['aws_id']
+    node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = vol[:aws_id]
     node.save unless Chef::Config[:solo]
     new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
The source of the volume_id value is in the RightAws `ec2.describe_volumes` call ...as such it doesn't seem to offer any magic handling of symbol vs string keys the way that Chef does with attributes.

So it needed to be accessed via a symbol key, with a string key it was returning `null`.
