### PR TITLE
[COOK-2605] Fix needless "missing 'right_aws'" warning

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -1,10 +1,21 @@
-# TODO: once sync_libraries properly handles sub-directories, move this file to aws/libraries/opscode/aws/ec2.rb
+#
+# Copyright:: Copyright (c) 2009 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-begin
-  require 'right_aws'
-rescue LoadError
-  Chef::Log.warn("Missing gem 'right_aws'")
-end
+# TODO: once sync_libraries properly handles sub-directories, move this file to aws/libraries/opscode/aws/ec2.rb
 
 require 'open-uri'
 
@@ -24,6 +35,12 @@ module Opscode
       end
 
       def ec2
+        begin
+          require 'right_aws'
+        rescue LoadError
+          Chef::Log.error("Missing gem 'right_aws'. Use the default aws recipe to install it first.")
+        end
+
         region = instance_availability_zone
         region = region[0, region.length-1]
         @@ec2 ||= RightAws::Ec2.new(new_resource.aws_access_key, new_resource.aws_secret_access_key, { :logger => Chef::Log, :region => region })


### PR DESCRIPTION
Only complain about the right_aws gem being missing when actually trying to evaluate & create the ec2 object.
