### PR TITLE
[COOK-1355] Using new RightAWS API for elastic_ip

### DIFF
--- a/providers/elastic_ip.rb
+++ b/providers/elastic_ip.rb
@@ -42,7 +42,7 @@ def address(ip)
 end
 
 def attach(ip, timeout)
-  ec2.associate_address(instance_id, ip)
+  ec2.associate_address(instance_id, {:public_ip => ip})
 
   # block until attached
   begin
@@ -66,7 +66,7 @@ def attach(ip, timeout)
 end
 
 def detach(ip, timeout)
-  ec2.disassociate_address(ip)
+  ec2.disassociate_address({:public_ip => ip})
 
   # block until detached
   begin


### PR DESCRIPTION
https://github.com/rightscale/right_aws/blob/master/lib/ec2/right_ec2.rb#L293

RightAWS now takes a hash such as {:public_ip => ip} vs. just IP for assoc/disassoc of elastic IPs.

Applied fix found in COOK-1355.
