### PR TITLE
COOK-2659: Fix volume_compatible_with_resource_definition?

### DIFF
--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -146,7 +146,7 @@ def volume_compatible_with_resource_definition?(volume)
   end
   (new_resource.size.nil? || new_resource.size == volume[:aws_size]) &&
   (new_resource.availability_zone.nil? || new_resource.availability_zone == volume[:zone]) &&
-  (new_resource.snapshot_id == volume[:snapshot_id])
+  (new_resource.snapshot_id.nil? || new_resource.snapshot_id == volume[:snapshot_id])
 end
 
 # Creates a volume according to specifications and blocks until done (or times out)


### PR DESCRIPTION
If the new resource does not specify a snapshot_id, the check to see if
we have an existing volume will always fail if the existing volume had a
snapshot made elsewhere. The fix is to bypass the volume snapshot
comparison if the new_resource snapshot_id is nil.
