### PR TITLE
Add support for mounting existing raids and reusing volumes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Attribute Parameters:
 * `disk_type` - "standard" or "io1" (io1 is the type for IOPS volume)
 * `disk_piops` - number of Provisioned IOPS to provision per disk,
   must be > 100
+* `existing_raid` - whether or not to assume the raid was already
+  assembled in the past on existing volumes (default no)
 
 ## elastic_ip.rb
 

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -25,7 +25,8 @@ action :auto_attach do
                       @new_resource.filesystem_options,
                       @new_resource.snapshots,
                       @new_resource.disk_type,
-                      @new_resource.disk_piops)
+                      @new_resource.disk_piops,
+                      @new_resource.existing_raid)
     
     @new_resource.updated_by_last_action(true)
   end
@@ -275,7 +276,8 @@ end
 #              If it's not nil, must have exactly <num_disks> elements
 
 def create_raid_disks(mount_point, num_disks, disk_size,
-                      level, filesystem, filesystem_options, snapshots, disk_type, disk_piops)
+                      level, filesystem, filesystem_options, snapshots, disk_type, disk_piops,
+                      existing_raid)
   
   creating_from_snapshot = !(snapshots.nil? || snapshots.size == 0)
 
@@ -327,11 +329,11 @@ def create_raid_disks(mount_point, num_disks, disk_size,
   devices_string = device_map_to_string(devices)
   Chef::Log.info("finished sorting devices #{devices_string}")
 
-  if not creating_from_snapshot
+  if not creating_from_snapshot and not existing_raid
     # Create the raid device on our system
     execute "creating raid device" do
       Chef::Log.info("creating raid device /dev/#{raid_dev} with raid devices #{devices_string}")
-      command "mdadm --create /dev/#{raid_dev} --level=#{level} --raid-devices=#{devices.size} #{devices_string}"
+      command "[ -b /dev/#{raid_dev} ] && mdadm --stop /dev/#{raid_dev} ; yes | mdadm --create /dev/#{raid_dev} --level=#{level} --raid-devices=#{devices.size} #{devices_string}"
     end
   
     # NOTE: must be a better way.

--- a/resources/ebs_raid.rb
+++ b/resources/ebs_raid.rb
@@ -11,4 +11,5 @@ attribute :filesystem_options, :default => "rw,noatime,nobootwait"
 attribute :snapshots,          :default => []
 attribute :disk_type,          :kind_of => String, :default => 'standard'
 attribute :disk_piops,         :kind_of => Integer, :default => 0
+attribute :existing_raid,      :kind_of => [ TrueClass, FalseClass ]
 


### PR DESCRIPTION
I came across two unsupported scenarios that involve re-using existing EBS volumes:
* Attach and mount a previously created RAID to a new node.
* Reuse existing volumes but create a new RAID.

My quick solution was to pre-populate node[:aws][:ebs_volume] with the correct mapping before proceeding to create the raid, and add the following changes:
* Provide an 'existing_raid' option that will re-configure the existing raid without re-creating it.
* Handle cases where the raid was auto-created when attached by deleting it before trying to re-create it.
