### PR TITLE
Fix typo in ebs_raid

### DIFF
--- a/resources/ebs_raid.rb
+++ b/resources/ebs_raid.rb
@@ -5,7 +5,7 @@ default_action :auto_attach
 attribute :mount_point,        :kind_of => String
 attribute :mount_point_owner,  :kind_of => String, :default => 'root'
 attribute :mount_point_group,  :kind_of => String, :default => 'root'
-attribtue :mount_point_mode,   :kind_of => String, :default => 00755
+attribute :mount_point_mode,   :kind_of => String, :default => 00755
 attribute :disk_count,         :kind_of => Integer
 attribute :disk_size,          :kind_of => Integer
 attribute :level,              :default => 10


### PR DESCRIPTION
Small typo in resources/ebs_raid.rb, breaks any other cookbooks trying to use this one.
