### PR TITLE
Resolved device mapping issues (Xen) in aws_ebs_raid LWRP

### DIFF
--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -50,7 +50,7 @@ def find_free_volume_device_prefix
 
   begin
     vol_dev = vol_dev.next
-    base_device = "/dev/#{vol_dev}1"
+    base_device = "/dev/#{vol_dev.sub(%r{\As}, 'xv')}1"
     Chef::Log.info("dev pre trim #{base_device}")
   end while ::File.exists?(base_device)
 
@@ -221,18 +221,14 @@ def mount_volumes(device_vol_map)
     attach_volume(dev_device, device_vol_map[dev_device])
   end
 
+  correct_devices = correct_device_map(device_vol_map).keys.map { |dev| "/dev/#{dev}" }
   # Wait until all volumes are mounted
   ruby_block "wait_#{new_resource.name}" do
     block do
-      count = 0
-      begin
-        Chef::Log.info("sleeping 10 seconds until EBS volumes have re-attached")
-        sleep 10
-        count += 1
-      end while !device_vol_map.all? {|dev_path| ::File.exists?(dev_path) }
-
-      # Accounting to see how often this code actually gets used.
-      node.set[:aws][:raid][mount_point][:device_attach_delay] = count * 10
+      while not correct_devices.all? { |dev_path| ::File.exists?(dev_path) }
+        Chef::Log.info("sleeping 3 seconds until EBS volumes have re-attached")
+        sleep 3
+      end
     end
   end
 end


### PR DESCRIPTION
I've found a couple of issues while trying to use the aws_ebs_raid LWRP, especially when making multiple raid devices during the same chef-client run.

Additionally, I changed the way the ruby_block[new_resource.name] runs to sleep only if necessary (it was always sleeping 10 seconds before checking for presence of devices.
