### PR TITLE
Allow setting aws_access_key and aws_secret_access_key for ebs_raid LWRP

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "LWRPs for managing AWS resources"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.101.3"
+version           "0.101.4"
 recipe            "aws", "Installs the right_aws gem during compile time"

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -295,13 +295,11 @@ end
 def attach_volume(disk_dev, volume_id)
   disk_dev_path = "/dev/#{disk_dev}"
 
-  aws = data_bag_item(node['aws']['databag_name'], node['aws']['databag_entry'])
-
   Chef::Log.info("Attaching existing ebs volume id #{volume_id} for device #{disk_dev_path}")
 
   aws_ebs_volume disk_dev_path do
-    aws_access_key          aws['aws_access_key_id']
-    aws_secret_access_key   aws['aws_secret_access_key']
+    aws_access_key          new_resource.aws_access_key
+    aws_secret_access_key   new_resource.aws_secret_access_key
     device                  disk_dev_path
     name                    disk_dev
     volume_id               volume_id
@@ -337,12 +335,10 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
 
     disk_dev_path = "#{disk_dev}#{i}"
 
-    aws = data_bag_item(node['aws']['databag_name'], node['aws']['databag_entry'])
-
     Chef::Log.info "Snapshot array is #{snapshots[i-1]}"
     aws_ebs_volume disk_dev_path do
-      aws_access_key          aws['aws_access_key_id']
-      aws_secret_access_key   aws['aws_secret_access_key']
+      aws_access_key          new_resource.aws_access_key
+      aws_secret_access_key   new_resource.aws_secret_access_key
       size                    disk_size
       volume_type             disk_type
       piops                   disk_piops

--- a/resources/ebs_raid.rb
+++ b/resources/ebs_raid.rb
@@ -2,16 +2,18 @@ actions :auto_attach
 
 default_action :auto_attach
 
-attribute :mount_point,        :kind_of => String
-attribute :mount_point_owner,  :kind_of => String, :default => 'root'
-attribute :mount_point_group,  :kind_of => String, :default => 'root'
-attribute :mount_point_mode,   :kind_of => String, :default => 00755
-attribute :disk_count,         :kind_of => Integer
-attribute :disk_size,          :kind_of => Integer
-attribute :level,              :default => 10
-attribute :filesystem,         :default => "ext4"
-attribute :filesystem_options, :default => "rw,noatime,nobootwait"
-attribute :snapshots,          :default => []
-attribute :disk_type,          :kind_of => String, :default => 'standard'
-attribute :disk_piops,         :kind_of => Integer, :default => 0
+attribute :aws_access_key,        :kind_of => String
+attribute :aws_secret_access_key, :kind_of => String
+attribute :mount_point,           :kind_of => String
+attribute :mount_point_owner,     :kind_of => String,                 :default => 'root'
+attribute :mount_point_group,     :kind_of => String,                 :default => 'root'
+attribute :mount_point_mode,      :kind_of => String,                 :default => 00755
+attribute :disk_count,            :kind_of => Integer
+attribute :disk_size,             :kind_of => Integer
+attribute :level,                 :default => 10
+attribute :filesystem,            :default => "ext4"
+attribute :filesystem_options,    :default => "rw,noatime,nobootwait"
+attribute :snapshots,             :default => []
+attribute :disk_type,             :kind_of => String,                 :default => 'standard'
+attribute :disk_piops,            :kind_of => Integer,                :default => 0
 


### PR DESCRIPTION
Updated aws_ebs_raid LWRP to allow passing aws_access_key and aws_secret_access_key as parameters to the LWRP.  It was taking them from a databag.  We use encrypted databags for our AWS credentials, and would thus rather pass the keys in to the LWRP.  This is in line with the aws_ebs_volume LWRP provided by the same cookbook.
