### PR TITLE
[COOK-4415] disk_existing_raid resource name inconsistency

### DIFF
--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -35,7 +35,7 @@ action :auto_attach do
                       @new_resource.snapshots,
                       @new_resource.disk_type,
                       @new_resource.disk_piops,
-                      @new_resource.disk_existing_raid)
+                      @new_resource.existing_raid)
 
     @new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
Quick fix for a naming inconsistency in the ebs_raid provider.
