### PR TITLE
Support XFS as ebs_raid filesystem. Tweak README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Attribute Parameters:
 * `disk_size` - size of EBS volumes to raid
 * `level` - RAID level (default 10)
 * `filesystem` - filesystem to format raid array. 'ext4' or 'xfs'
-  currently supported.
+  currently supported (default: 'ext4')
 * `snapshots` - array of EBS snapshots to restore. Snapshots must be
   taken using an ec2 consistent snapshot tool, and tagged with a
   number that indicates how many devices are in the array being backed

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Attribute Parameters:
 
 Manage Elastic Block Store (EBS) raid devices with this resource.
 
+Actions:
+
+* `auto_attach` - creates RAID device and attaches.
+
 Attribute Parameters:
 
 * `aws_secret_access_key`, `aws_access_key` - passed to
@@ -210,7 +214,8 @@ Attribute Parameters:
 * `disk_count` - number of EBS volumes to raid
 * `disk_size` - size of EBS volumes to raid
 * `level` - RAID level (default 10)
-* `filesystem` - filesystem to format raid array (default ext4)
+* `filesystem` - filesystem to format raid array. 'ext4' or 'xfs'
+  currently supported.
 * `snapshots` - array of EBS snapshots to restore. Snapshots must be
   taken using an ec2 consistent snapshot tool, and tagged with a
   number that indicates how many devices are in the array being backed

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,3 +6,5 @@ description       "LWRPs for managing AWS resources"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "2.1.2"
 recipe            "aws", "Installs the right_aws gem during compile time"
+
+depends "xfs"

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -390,9 +390,12 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
         case filesystem
           when "ext4"
             system("mke2fs -t #{filesystem} -F #{md_device}")
+          when "xfs"
+            include_recipe 'xfs'
+            system("mkfs -t #{filesystem} -F #{md_device}")
           else
             #TODO fill in details on how to format other filesystems here
-            Chef::Log.info("Can't format filesystem #{filesystem}")
+            Chef::Log.info("Can't format filesystem #{filesystem}. Only ext4 or xfs currently supported.")
         end
       end
     end

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -392,7 +392,7 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
             system("mke2fs -t #{filesystem} -F #{md_device}")
           when "xfs"
             include_recipe 'xfs'
-            system("mkfs -t #{filesystem} -F #{md_device}")
+            system("mkfs -t #{filesystem} #{md_device}")
           else
             #TODO fill in details on how to format other filesystems here
             Chef::Log.info("Can't format filesystem #{filesystem}. Only ext4 or xfs currently supported.")

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -391,7 +391,7 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
           when "ext4"
             system("mke2fs -t #{filesystem} -F #{md_device}")
           when "xfs"
-            include_recipe 'xfs'
+            run_context.include_recipe 'xfs'
             system("mkfs -t #{filesystem} #{md_device}")
           else
             #TODO fill in details on how to format other filesystems here


### PR DESCRIPTION
This could be generalised to a single

    mkfs -t #{filesystem} #{md_device}

but this approach ensures xfs tools are available if required.