### PR TITLE
Add ability to enable detailed CloudWatch monitoring for current instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,18 @@ Attribute Parameters
   be a single ID as a string or multiple IDs in an array. If no
   `resource_id` is specified the name attribute will be used.
 
+## instance_monitoring.rb
+
+Actions:
+
+* `enable` - Enable detailed CloudWatch monitoring for this instance (Default).
+* `disable` - Disable detailed CloudWatch monitoring for this instance.
+
+Attribute Parameters:
+
+* `aws_secret_access_key`, `aws_access_key` - passed to
+  `Opscode::AWS:Ec2` to authenticate, required, unless using IAM roles for authentication.
+
 Usage
 =====
 
@@ -411,6 +423,12 @@ is a wrapper around `remote_file` and supports the same resource attributes as `
       aws_secret_access_key aws['aws_secret_access_key']
     end
 
+
+## aws_instance_monitoring
+
+Allows detailed CloudWatch monitoring to be enabled for the current instance.
+
+    aws_instance_monitoring "enable detailed monitoring"
 
 License and Author
 ==================

--- a/providers/instance_monitoring.rb
+++ b/providers/instance_monitoring.rb
@@ -1,0 +1,35 @@
+include Opscode::Aws::Ec2
+
+def whyrun_supported?
+  true
+end
+
+action :enable do
+  if is_monitoring_enabled
+    Chef::Log.debug("Monitoring is already enabled for this instance")
+  else
+    converge_by("enable monitoring for this instance") do
+      Chef::Log.info("Enabling monitoring for this instance")
+      ec2.monitor_instances(instance_id)
+    end
+  end
+end
+
+action :disable do
+  if is_monitoring_enabled
+    converge_by("disable monitoring for this instance") do
+      Chef::Log.info("Disabling monitoring for this instance")
+      ec2.unmonitor_instances(instance_id)
+    end
+  else
+    Chef::Log.debug("Monitoring is already disabled for this instance")
+  end
+end
+
+private
+
+def is_monitoring_enabled()
+  monitoring_state = ec2.describe_instances(instance_id)[0][:monitoring_state]
+  Chef::Log.info("Current monitoring state for this instance is #{monitoring_state}")
+  return monitoring_state == "enabled"
+end

--- a/resources/instance_monitoring.rb
+++ b/resources/instance_monitoring.rb
@@ -1,0 +1,11 @@
+def initialize(*args)
+  super
+  @action = :enable
+end
+
+actions :enable, :disable
+
+state_attrs :aws_access_key
+
+attribute :aws_access_key, :kind_of => String
+attribute :aws_secret_access_key, :kind_of => String


### PR DESCRIPTION
Add aws_enable_monitoring that allows switching from basic to detailed monitoring of the current instance.
