### PR TITLE
Require ec2 since we need it

### DIFF
--- a/libraries/elb.rb
+++ b/libraries/elb.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), 'ec2')
+
 module Opscode
   module Aws
     module Elb


### PR DESCRIPTION
We can't depend on Ruby globbing order
