### PR TITLE
Added support for provisioning General Purpose (SSD) volumes (gp2)

### DIFF
--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -153,7 +153,7 @@ def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, pi
   availability_zone ||= instance_availability_zone
 
   # Sanity checks so we don't shoot ourselves.
-  raise "Invalid volume type: #{volume_type}" unless ['standard', 'io1'].include?(volume_type)
+  raise "Invalid volume type: #{volume_type}" unless ['standard', 'io1', 'gp2'].include?(volume_type)
 
   # PIOPs requested. Must specify an iops param and probably won't be "low".
   if volume_type == 'io1'


### PR DESCRIPTION
Adding support for the recently-announced General Purpose (SSD) volume types to the aws_ebs_volume LWRP.

More info here: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
