### PR TITLE
Jcc hvm raid fix

### DIFF
--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -48,9 +48,8 @@ private
 # Returns the 3-letter dev name (no trailing digit for hvm compat).
 # However, we test for an existing dev file both with and without a
 # trailing '1' just in case.
-def find_free_volume_device_prefix
-  # Specific to ubuntu 11./12.
-  vol_dev = "sde"
+def find_free_volume_device_prefix(vol_dev="sde")
+  # "sd" dev name specific to ubuntu 11./12.
 
   begin
     vol_dev = vol_dev.next
@@ -328,12 +327,13 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
   Chef::Log.debug("target raid device is #{raid_dev}")
 
   devices = {}
+  disk_dev_path = "sde"
 
   # For each volume add information to the mount metadata
   (1..num_disks).each do |i|
 
-    disk_dev_path = find_free_volume_device_prefix
-    Chef::Log.debug("vol device prefix is #{disk_dev}")
+    disk_dev_path = find_free_volume_device_prefix(disk_dev_path)
+    Chef::Log.debug("vol device prefix is #{disk_dev_path}")
 
     Chef::Log.info "Snapshot array is #{snapshots[i-1]}"
     creds = aws_creds() # cannot be invoked inside the block

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -44,16 +44,19 @@ end
 private
 
 # AWS's volume attachment interface assumes that we're using
-# sdX style device names.  The ones we actually get will be xvdX
+# sdX style device names.  The ones we actually get will be xvdX.
+# Returns the 3-letter dev name (no trailing digit for hvm compat).
+# However, we test for an existing dev file both with and without a
+# trailing '1' just in case.
 def find_free_volume_device_prefix
   # Specific to ubuntu 11./12.
-  vol_dev = "sdh"
+  vol_dev = "sde"
 
   begin
     vol_dev = vol_dev.next
-    base_device = "/dev/#{vol_dev}1"
+    base_device = "/dev/#{vol_dev}"
     Chef::Log.info("dev pre trim #{base_device}")
-  end while ::File.exists?(base_device)
+  end while (::File.exists?(base_device) or ::File.exists?("#{base_device}1"))
 
   vol_dev
 end
@@ -321,9 +324,6 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
 
   creating_from_snapshot = !(snapshots.nil? || snapshots.size == 0)
 
-  disk_dev = find_free_volume_device_prefix
-  Chef::Log.debug("vol device prefix is #{disk_dev}")
-
   raid_dev = find_free_md_device_name
   Chef::Log.debug("target raid device is #{raid_dev}")
 
@@ -332,7 +332,8 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
   # For each volume add information to the mount metadata
   (1..num_disks).each do |i|
 
-    disk_dev_path = "#{disk_dev}#{i}"
+    disk_dev_path = find_free_volume_device_prefix
+    Chef::Log.debug("vol device prefix is #{disk_dev}")
 
     Chef::Log.info "Snapshot array is #{snapshots[i-1]}"
     creds = aws_creds() # cannot be invoked inside the block


### PR DESCRIPTION
Somewhat primitive but effective fix for ebs_raid that moves from creating devices named sdX1, sdX2, ... to instead creating devices named sdf, sdg, sdh, etc.  This is needed to support HVM images (still works with PV images).  This fix addresses this ticket: https://tickets.opscode.com/browse/COOK-4600.

I call it primitive because it would be nice to have an option allowing the use of either naming style on demand.  It's a start though.
