### PR TITLE
add support for HVM instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Attribute Parameters:
 * `volume_type` - "standard", "io1", or "gp2" ("standard" is magnetic, "io1" is piops SSD, "gp2" is general purpose SSD)
 * `piops` - number of Provisioned IOPS to provision, must be >= 100
 * `existing_raid` - whether or not to assume the raid was previously assembled on existing volumes (default no)
+* `hvm` - if set to true, device names will use the sdX convention instead of sdxX in order to support HVM instances (default false)
 
 ## ebs_raid.rb
 

--- a/resources/ebs_raid.rb
+++ b/resources/ebs_raid.rb
@@ -32,4 +32,5 @@ attribute :snapshots,             :default => []
 attribute :disk_type,             :kind_of => String, :default => 'standard'
 attribute :disk_piops,            :kind_of => Integer, :default => 0
 attribute :existing_raid,         :kind_of => [ TrueClass, FalseClass ]
+attribute :hvm,                   :kind_of => [ TrueClass, FalseClass ], :default => false
 


### PR DESCRIPTION
When using the ebs_raid provider to create and attached volumes to a HVM instance you will receive the following error:

    RightAws::AwsError
    ------------------
    InvalidParameterValue: Value (/dev/sdi1) for parameter device is invalid. /dev/sdi1 is not a valid EBS device name.

This is because the ebs_raid provider hard-codes a digit after the device name (i.e. sdi1, sdi2, etc.)

http://docs.amazonaws.cn/en_us/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html states:
> Hardware virtual machine (HVM) AMIs (such as the base Windows and Cluster Compute images) do not support the use of > trailing numbers on device names (xvd[a-p][1-15]).

Existing ticket:
https://tickets.opscode.com/browse/COOK-4600

My pull request addresses the issue by adding support for HVM instances without effecting the existing functionality of the provider because hvm is set to false by default.