### PR TITLE
Add support for Elastic Network Interfaces

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -88,6 +88,18 @@ suites:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
         elastic_ip: <%= ENV['AWS_ELASTIC_IP'] %>
+        elastic_network_interface_id: <%= ENV['AWS_ELASTIC_NETWORK_INTERFACE_ID'] %>
+
+  - name: elastic_network_interface
+    run_list:
+    - recipe[aws_test::elastic_network_interface]
+    attributes:
+      aws_test:
+        key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+        access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+        elastic_network_interface_id: <%= ENV['AWS_ELASTIC_NETWORK_INTERFACE_ID'] %>
+        elastic_network_interface_device_index: <%= ENV['AWS_ELASTIC_NETWORK_INTERFACE_DEVICE_INDEX'] %>
+        elastic_ip: <%= ENV['AWS_ELASTIC_IP'] %>
 
   - name: elb
     run_list:

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -13,7 +13,7 @@ platforms:
 - name: amazon-2014.09
   driver_plugin: ec2
   driver_config:
-    image_id: ami-50842d38
+    image_id: ami-8e682ce6
     username: ec2-user
     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
     flavor_id: m1.small
@@ -21,7 +21,7 @@ platforms:
 - name: ubuntu-12.04
   driver_plugin: ec2
   driver_config:
-    image_id: ami-2ccc7a44
+    image_id: ami-00ab0168
     username: ubuntu
     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
     flavor_id: m1.small
@@ -29,7 +29,7 @@ platforms:
 - name: ubuntu-12.04-hvm
   driver_plugin: ec2
   driver_config:
-    image_id: ami-3ccc7a54
+    image_id: ami-10ab0178
     username: ubuntu
     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
     flavor_id: t2.small
@@ -37,7 +37,7 @@ platforms:
 - name: ubuntu-14.04
   driver_plugin: ec2
   driver_config:
-    image_id: ami-8caa1ce4
+    image_id: ami-84562dec
     username: ubuntu
     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
     flavor_id: m1.small
@@ -45,7 +45,7 @@ platforms:
 - name: ubuntu-14.04-hvm
   driver_plugin: ec2
   driver_config:
-    image_id: ami-9aaa1cf2
+    image_id: ami-9a562df2
     username: ubuntu
     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
     flavor_id: t2.small
@@ -53,7 +53,7 @@ platforms:
 - name: amazon-2014.09-hvm
   driver_plugin: ec2
   driver_config:
-    image_id: ami-fccc6d94
+    image_id: ami-146e2a7c
     username: ec2-user
     ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
     flavor_id: t2.small

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Attribute Parameters:
 * `aws_secret_access_key`, `aws_access_key` - passed to
   `Opscode::AWS:Ec2` to authenticate, required, unless using IAM roles for authentication.
 * `ip` - the IP address.
+* `network_interface_id` - the Elastic Network Interface to attach the Elastic IP to. If specified, the network interface must be attached to the instance before associating the Elastic IP to the network interface. Otherwise, the AWS API will timeout.
 * `timeout` - connection timeout for EC2 API.
 
 ## elastic_network_interface.rb

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ API. Currently supported resources:
 * EBS Volumes (`ebs_volume`)
 * EBS Raid (`ebs_raid`)
 * Elastic IPs (`elastic_ip`)
+* Elastic Network Interfaces (`elastic_network_interface`)
 * Elastic Load Balancer (`elastic_lb`)
 * AWS Resource Tags (`resource_tag`)
 
@@ -231,6 +232,25 @@ Attribute Parameters:
 * `ip` - the IP address.
 * `timeout` - connection timeout for EC2 API.
 
+## elastic_network_interface.rb
+
+Actions:
+
+* `attach` - attach the network interface.
+* `detach` - detach the network interface.
+* `create` - create a network interface.
+
+Attribute Parameters:
+
+* `aws_secret_access_key`, `aws_access_key` - passed to
+  `Opscode::AWS:Ec2` to authenticate, required, unless using IAM roles for authentication.
+* `network_interface_id` - the network interface id. Required for `:attach` and `:detach` actions.
+* `device_index` - the index for the network interface to attach to. Required for `:attach` action.
+* `subnet_id` - the subnet of the network interface. Required for `:create` action.
+* `private_ip_addresses` - array of private ip addresses to assign to the network interface on creation. Only used for `:create` action.
+* `groups` - security groups to apply to the network interface on creation. Only used for `:create` action.
+* `timeout` - connection timeout for EC2 API.
+
 ## elastic_lb.rb
 
 Actions:
@@ -348,6 +368,31 @@ required values into the resource to configure. Note that when
 associating an Elastic IP to an instance, connectivity to the instance
 will be lost because the public IP address is changed. You will need
 to reconnect to the instance with the new IP.
+
+You can also store this in a role as an attribute or assign to the
+node directly, if preferred.
+
+## aws_elastic_network_interface
+
+The `elastic_network_interface` resource provider does not support creating new
+network interfaces. This must be done before running a recipe that uses the resource.
+After creating a new Elastic Network Interface, we recommend storing it in a
+databag and loading the item in the recipe.
+
+To set up an existing Elastic Network Interface on a system:
+
+    eni_info = data_bag_item("aws", "eni")
+
+    aws_elastic_network_interface "eni" do
+      aws_access_key aws['aws_access_key_id']
+      aws_secret_access_key aws['aws_secret_access_key']
+      network_interface_id eni_info['network_interface_id']
+      device_index eni_info['device_index']
+      action [:create, :associate]
+    end
+
+This will use the loaded `aws` and `eni_info` databags to pass the
+required values into the resource to configure.
 
 You can also store this in a role as an attribute or assign to the
 node directly, if preferred.

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -39,6 +39,10 @@ module Opscode
         snapshot_id
       end
 
+      def get_network_interface(interface_id)
+        ec2.describe_network_interfaces(network_interface_ids: [interface_id])[:network_interfaces].find { |ni| ni[:network_interface_id] == interface_id }
+      end
+
       def ec2
         @@ec2 ||= create_aws_interface(::Aws::EC2::Client)
       end

--- a/providers/elastic_ip.rb
+++ b/providers/elastic_ip.rb
@@ -7,16 +7,23 @@ end
 
 action :associate do
   ip = new_resource.ip || node['aws']['elastic_ip'][new_resource.name]['ip']
+  network_interface_id = new_resource.network_interface_id
+
   addr = address(ip)
+  net_interface = nil
+  unless network_interface_id.nil?
+    net_interface = get_network_interface(network_interface_id)
+  end
 
   if addr.nil?
     fail "Elastic IP #{ip} does not exist"
-  elsif addr[:instance_id] == instance_id
-    Chef::Log.debug("Elastic IP #{ip} is already attached to the instance")
+  elsif !net_interface.nil? && !net_interface[:attachment].nil? && net_interface[:attachment][:instance_id] != instance_id
+    fail "Elastic Network Interface #{network_interface_id} is attached to another instance"
   else
     converge_by("attach Elastic IP #{ip} to the instance") do
       Chef::Log.info("Attaching Elastic IP #{ip} to the instance")
-      attach(ip, new_resource.timeout)
+      # attach() is idempotent http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#associate_address-instance_method
+      attach(ip, network_interface_id, new_resource.timeout)
       node.set['aws']['elastic_ip'][new_resource.name]['ip'] = ip
       node.save unless Chef::Config[:solo]
     end
@@ -59,12 +66,21 @@ def address(ip)
   ec2.describe_addresses[:addresses].find { |a| a[:public_ip] == ip }
 end
 
-def attach(ip, timeout)
+def attach(ip, network_interface_id, timeout)
   addr = address(ip)
+
   if addr[:domain] == 'vpc'
-    ec2.associate_address(instance_id: instance_id, allocation_id: addr[:allocation_id])
+    if network_interface_id.nil?
+      ec2.associate_address(instance_id: instance_id, allocation_id: addr[:allocation_id])
+    else
+      ec2.associate_address(network_interface_id: network_interface_id, allocation_id: addr[:allocation_id])
+    end
   else
-    ec2.associate_address(instance_id: instance_id, public_ip: addr[:public_ip])
+    if network_interface_id.nil?
+      ec2.associate_address(instance_id: instance_id, public_ip: addr[:public_ip])
+    else
+      ec2.associate_address(network_interface_id: network_interface_id, public_ip: addr[:public_ip])
+    end
   end
 
   # block until attached

--- a/providers/elastic_network_interface.rb
+++ b/providers/elastic_network_interface.rb
@@ -1,0 +1,119 @@
+include Opscode::Aws::Ec2
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :attach do
+  network_interface_id = new_resource.network_interface_id || node['aws']['elastic_network_interface'][new_resource.name]['network_interface_id']
+  device_index = new_resource.device_index || node['aws']['elastic_network_interface'][new_resource.name]['device_index']
+
+  net_interface = get_network_interface(network_interface_id)
+
+  if net_interface.nil?
+    fail "Elastic Network Interface #{network_interface_id} does not exist"
+  elsif !net_interface[:attachment].nil?
+    if net_interface[:attachment][:instance_id] == instance_id
+      Chef::Log.debug("Elastic Network Interface #{network_interface_id} is already attached to the instance")
+    else
+      fail "Elastic Network Interface #{network_interface_id} is attached to another instance"
+    end
+  else
+    converge_by("attach Elastic Network Interface #{network_interface_id} to the instance") do
+      Chef::Log.info("Attaching Elastic Network Interface #{network_interface_id} to the instance")
+      attach_interface(network_interface_id, device_index, new_resource.timeout)  # attach is idempotent http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#associate_address-instance_method
+      node.set['aws']['elastic_network_interface'][new_resource.name]['network_interface_id'] = network_interface_id
+      node.save unless Chef::Config[:solo]
+    end
+  end
+end
+
+action :detach do
+  network_interface_id = new_resource.network_interface_id || node['aws']['elastic_network_interface'][new_resource.name]['network_interface_id']
+
+  net_interface = get_network_interface(network_interface_id)
+
+  if net_interface.nil?
+    Chef::Log.debug("Elastic Network Interface #{network_interface_id} does not exist, so there is nothing to detach")
+  elsif net_interface[:attachment].nil? || net_interface[:attachment][:instance_id] != instance_id
+    Chef::Log.debug("Elastic Network Interface #{network_interface_id} is already detached from the instance")
+  else
+    converge_by("detach Elastic Network Interface #{network_interface_id} from the instance") do
+      Chef::Log.info("Detaching Elastic Network Interface #{network_interface_id} from the instance")
+      detach_interface(network_interface_id, new_resource.timeout)
+    end
+  end
+end
+
+action :create do
+  current_elastic_network_interface_id = node['aws']['elastic_network_interface'][new_resource.name]['network_interface_id']
+  if current_elastic_network_interface_id
+    Chef::Log.info("An Elastic Network Interface was already created for #{new_resource.name} #{current_elastic_ip} from the instance")
+  else
+    converge_by("create new Elastic Network Interface for #{new_resource.name}") do
+      net_interface = ec2.create_network_interface(subnet_id: new_resource.subnet_id, private_ip_addresses: new_resource.private_ip_addresses, groups: new_resource.groups)
+      Chef::Log.info("Created Elastic Network Interface #{net_interface[:network_interface_id]} from the instance")
+      node.set['aws']['elastic_network_interface'][new_resource.name]['network_interface_id'] = net_interface[:network_interface_id]
+      node.set['aws']['elastic_network_interface'][new_resource.name]['device_index'] = net_interface[:network_interface_id][:attachment][:device_index]
+      node.save unless Chef::Config[:solo]
+    end
+  end
+end
+
+private
+
+def attach_interface(network_interface_id, device_index, timeout)
+  ec2.attach_network_interface(instance_id: instance_id, network_interface_id: network_interface_id, device_index: device_index)
+
+  # block until attached
+  begin
+    Timeout.timeout(timeout) do
+      loop do
+        net_interface = get_network_interface(network_interface_id)
+        if net_interface.nil?
+          fail 'Elastic Network Interface has been deleted while waiting for attachment'
+        elsif net_interface[:attachment].nil?
+          next
+        elsif net_interface[:attachment][:instance_id] != instance_id
+          Chef::Log.debug("Elastic Network Interface is currently attached to #{net_interface[:attachment][:instance_id]}")
+        else
+          Chef::Log.debug('Elastic Network Interface is attached to this instance')
+          break
+        end
+        sleep 3
+      end
+    end
+  rescue Timeout::Error
+    raise "Timed out waiting for attachment after #{timeout} seconds"
+  end
+end
+
+def detach_interface(network_interface_id, timeout)
+  net_interface = get_network_interface(network_interface_id)
+  ec2.detach_network_interface(attachment_id: net_interface[:attachment][:attachment_id])
+
+  # block until detached
+  begin
+    Timeout.timeout(timeout) do
+      loop do
+        net_interface = get_network_interface(network_interface_id)
+        if net_interface.nil?
+          Chef::Log.debug('Elastic Network Interface has been deleted while waiting for detachment')
+          break
+        elsif net_interface[:attachment].nil?
+          Chef::Log.debug('Elastic Network Interface is detached from this instance')
+          break
+        elsif net_interface[:attachment][:instance_id] != instance_id
+          Chef::Log.debug('Elastic Network Interface is detached from this instance')
+          break
+        else
+          Chef::Log.debug('Elastic Network Interface is still attached')
+        end
+        sleep 3
+      end
+    end
+  rescue Timeout::Error
+    raise "Timed out waiting for detachment after #{timeout} seconds"
+  end
+end

--- a/resources/elastic_ip.rb
+++ b/resources/elastic_ip.rb
@@ -2,11 +2,13 @@ actions :associate, :disassociate, :allocate
 
 state_attrs :aws_access_key,
             :ip,
+            :network_interface_id,
             :timeout
 
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :ip,                    kind_of: String, name_attribute: true
+attribute :network_interface_id,  kind_of: String
 attribute :timeout,               default: 3 * 60 # 3 mins, nil or 0 for no timeout
 
 def initialize(*args)

--- a/resources/elastic_network_interface.rb
+++ b/resources/elastic_network_interface.rb
@@ -1,0 +1,23 @@
+actions :attach, :detach, :create
+
+state_attrs :aws_access_key,
+            :network_interface_id,
+            :device_index,
+            :subnet_id,
+            :private_ip_addresses,
+            :groups,
+            :timeout
+
+attribute :aws_access_key,        kind_of: String
+attribute :aws_secret_access_key, kind_of: String
+attribute :network_interface_id,  kind_of: String, name_attribute: true
+attribute :device_index,          kind_of: String
+attribute :subnet_id,             kind_of: String
+attribute :private_ip_addresses,  kind_of: Array
+attribute :groups,                kind_of: Array
+attribute :timeout,               default: 3 * 60 # 3 mins, nil or 0 for no timeout
+
+def initialize(*args)
+  super
+  @action = :attach
+end

--- a/test/fixtures/cookbooks/aws_test/recipes/elastic_network_interface.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/elastic_network_interface.rb
@@ -1,0 +1,17 @@
+include_recipe 'aws'
+
+aws_elastic_network_interface 'elastic_network_interface' do
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  network_interface_id node['aws_test']['elastic_network_interface_id']
+  device_index node['aws_test']['elastic_network_interface_device_index'].to_s
+  action :attach
+end
+
+aws_elastic_ip 'elastic_ip' do
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  ip node['aws_test']['elastic_ip']
+  network_interface_id node['aws_test']['elastic_network_interface_id']
+  action :associate
+end


### PR DESCRIPTION
I took a first pass of editing the README.

I only tested the `elastic_ip` and `elastic_network_interface` providers since those are the only providers that changed.
I tested the providers using the commands:

``` bash
KITCHEN_YAML=".kitchen.cloud.yml" AWS_KEYPAIR_NAME="test-kitchen" EC2_SSH_KEY_PATH="test-kitchen.pem" AWS_ACCESS_KEY_ID="XXXX" AWS_SECRET_ACCESS_KEY="XXXX" AWS_ELASTIC_IP="X.X.X.X" AWS_ELASTIC_NETWORK_INTERFACE_ID="eni-XXXX" AWS_ELASTIC_NETWORK_INTERFACE_DEVICE_INDEX="1" AWS_ELB_NAME="test-kitchen" AWS_S3_BUCKET="test-kitchen" AWS_S3_KEY="test-aws-cookbook-file" kitchen test elastic-ip
```

and

``` bash
KITCHEN_YAML=".kitchen.cloud.yml" AWS_KEYPAIR_NAME="test-kitchen" EC2_SSH_KEY_PATH="test-kitchen.pem" AWS_ACCESS_KEY_ID="XXXX" AWS_SECRET_ACCESS_KEY="XXXX" AWS_ELASTIC_IP="X.X.X.X" AWS_ELASTIC_NETWORK_INTERFACE_ID="eni-XXXX" AWS_ELASTIC_NETWORK_INTERFACE_DEVICE_INDEX="1" AWS_ELB_NAME="test-kitchen" AWS_S3_BUCKET="test-kitchen" AWS_S3_KEY="test-aws-cookbook-file" kitchen test elastic-network-interface
```

I modified, but didn't submit changes for, the `driver_config` section of `.kitchen.cloud.yml` to specify a `subnet_id` for testing the `elastic_network_interface` provider. I didn't submit the changes b/c not every test would needs the change and wasn't sure if you guys wanted to make `subnet_id` a required environment variable for test runs.

I also updated the public AMI images for all the specified platforms since I couldn't find the existing AMIs in the default region (`us-east-1`).
