### PR TITLE
Fix detach action for ebs_volume provider.

### DIFF
--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -242,12 +242,14 @@ end
 # Detaches the volume and blocks until done (or times out)
 def detach_volume(volume_id, timeout)
   vol = volume_by_id(volume_id)
-  if vol[:instance_id] != instance_id
-    Chef::Log.debug("EBS Volume #{volume_id} is not attached to this instance (attached to #{vol[:instance_id]}). Skipping...")
+  attachment = vol[:attachments].find { |a| a[:instance_id] == instance_id }
+  if attachment.nil?
+    attached_instance_ids = vol[:attachments].collect { |a| a[:instance_id] }
+    Chef::Log.debug("EBS Volume #{volume_id} is not attached to this instance (attached to #{attached_instance_ids}). Skipping...")
     return
   end
   Chef::Log.debug("Detaching #{volume_id}")
-  orig_instance_id = vol[:instance_id]
+  orig_instance_id = attachment[:instance_id]
   ec2.detach_volume(volume_id: volume_id)
 
   # block until detached
@@ -256,7 +258,8 @@ def detach_volume(volume_id, timeout)
       loop do
         vol = volume_by_id(volume_id)
         if vol && vol[:state] != 'deleting'
-          if vol[:instance_id] != orig_instance_id
+          poll_attachment = vol[:attachments].find { |a| a[:instance_id] == instance_id }
+          if poll_attachment.nil?
             Chef::Log.info("Volume detached from #{orig_instance_id}")
             break
           else

--- a/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
@@ -5,5 +5,5 @@ aws_ebs_volume 'db_ebs_volume' do
   aws_secret_access_key node['aws_test']['access_key']
   size 50
   device '/dev/sdi'
-  action [:create, :attach]
+  action [:create, :attach, :detach]
 end


### PR DESCRIPTION
   - In the AWS SDK v2, instance_id is nested under the attachment `Array<Hash>`
   - http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#describe_volumes-instance_method