### PR TITLE
make libraries portable

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -63,7 +63,7 @@ module Opscode
         region = instance_availability_zone
         region = region[0, region.length - 1]
 
-        if !new_resource.aws_access_key.to_s.empty? && !new_resource.aws_secret_access_key.to_s.empty?
+        if defined?(new_resource) && !new_resource.aws_access_key.to_s.empty? && !new_resource.aws_secret_access_key.to_s.empty?
           creds = ::Aws::Credentials.new(new_resource.aws_access_key, new_resource.aws_secret_access_key, new_resource.aws_session_token)
         else
           Chef::Log.info('Attempting to use iam profile')


### PR DESCRIPTION
Check that new_resource exists at all to make the libraries usable outside of the LWRP of this cookbook when policies are in place for access.