### PR TITLE
EBSEncryptedRaid fixes to AWS cookbook 2.7.2 (Issue #164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ Attribute Parameters:
 * `disk_type` - "standard" or "io1" (io1 is the type for IOPS volume)
 * `disk_piops` - number of Provisioned IOPS to provision per disk,
   must be > 100
+* `disk_encrypted` - specify if the EBS volumes should be encrypted
+* `disk_kms_key_id` - the full ARN of the AWS Key Management Service
+  (AWS KMS) master key to use when creating the encrypted volumes
+  (defaults to master key if not specified)
 
 ## elastic_ip.rb
 

--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -34,7 +34,9 @@ action :auto_attach do
                       @new_resource.snapshots,
                       @new_resource.disk_type,
                       @new_resource.disk_piops,
-                      @new_resource.existing_raid)
+                      @new_resource.existing_raid,
+                      @new_resource.disk_encrypted,
+                      @new_resource.disk_kms_key_id)
 
     @new_resource.updated_by_last_action(true)
   end
@@ -317,7 +319,7 @@ end
 #              If it's not nil, must have exactly <num_disks> elements
 
 def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_point_mode, num_disks, disk_size,
-                      level, filesystem, filesystem_options, snapshots, disk_type, disk_piops, existing_raid)
+                      level, filesystem, filesystem_options, snapshots, disk_type, disk_piops, existing_raid, disk_encrypted, disk_kms_key_id)
 
   creating_from_snapshot = !(snapshots.nil? || snapshots.size == 0)
 
@@ -347,6 +349,8 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
       action [:create, :attach]
       snapshot_id creating_from_snapshot ? snapshots[i - 1] : nil
       provider 'aws_ebs_volume'
+      encrypted disk_encrypted
+      kms_key_id disk_kms_key_id
 
       # set up our data bag info
       devices[disk_dev_path] = 'pending'

--- a/resources/ebs_raid.rb
+++ b/resources/ebs_raid.rb
@@ -14,7 +14,9 @@ state_attrs :aws_access_key,
             :mount_point_group,
             :mount_point_mode,
             :mount_point_owner,
-            :snapshots
+            :snapshots,
+            :disk_encrypted,
+            :disk_kms_key_id
 
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
@@ -32,3 +34,5 @@ attribute :snapshots,             default: []
 attribute :disk_type,             kind_of: String, default: 'standard'
 attribute :disk_piops,            kind_of: Integer, default: 0
 attribute :existing_raid,         kind_of: [TrueClass, FalseClass]
+attribute :disk_encrypted,        kind_of: [TrueClass, FalseClass], default: false
+attribute :disk_kms_key_id,       kind_of: String


### PR DESCRIPTION
See Issue #164 

This has the proper passthrough for EBS Volumes to be created with encryption when created through the EBS_Raid resource.

History:

PR #114 brought in the ability to create Encrypted EBS volumes, however it didn't provide a passthrough for volumes created as part of a raid to be created with encryption.

I wrote PR #130 to fix this right after PR #114 was merged, but it included a general fix for EBS Raids that was sliced out into its own PR #156, which was recently merged. So I am submitting a new PR with just the remaining Encryption fix for volumes created in a Raid.
