### PR TITLE
Add require 'aws-sdk' as needed

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -42,6 +42,12 @@ module Opscode
       end
 
       def ec2
+        begin
+          require 'aws-sdk'
+        rescue LoadError
+          Chef::Log.error("Missing gem 'aws-sdk'. Use the default aws recipe to install it first.")
+        end
+
         @@ec2 ||= create_aws_interface(::Aws::EC2::Client)
       end
 

--- a/libraries/elb.rb
+++ b/libraries/elb.rb
@@ -6,6 +6,11 @@ module Opscode
       include Opscode::Aws::Ec2
 
       def elb
+        begin
+          require 'aws-sdk'
+        rescue LoadError
+          Chef::Log.error("Missing gem 'aws-sdk'. Use the default aws recipe to install it first.")
+        end
         @@elb ||= create_aws_interface(::Aws::ElasticLoadBalancing::Client)
       end
     end

--- a/libraries/s3.rb
+++ b/libraries/s3.rb
@@ -6,6 +6,11 @@ module Opscode
       include Opscode::Aws::Ec2
 
       def s3
+        begin
+          require 'aws-sdk'
+        rescue LoadError
+          Chef::Log.error("Missing gem 'aws-sdk'. Use the default aws recipe to install it first.")
+        end
         @@s3 ||= create_aws_interface(::Aws::S3::Client)
       end
     end


### PR DESCRIPTION
The aws-sdk gem namespace was being called before it was required.
Solves https://github.com/chef-cookbooks/aws/issues/181