### PR TITLE
Update default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['aws']['aws_sdk_version'] = '~> 2.2.3'
+default['aws']['aws_sdk_version'] = '~> 2.2'
 default['aws']['databag_name'] = nil
 default['aws']['databag_entry'] = nil
 default['aws']['region'] = nil


### PR DESCRIPTION
Adjust pessimistic version constraint to the major and minor. AWS-SDK project has demonstrated good use of versioning in the 2.x series.