### PR TITLE
Adding support for AssumeRole credentials

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -79,6 +79,11 @@ module Opscode
           Chef::Log.info('Attempting to use iam profile')
           creds = ::Aws::InstanceProfileCredentials.new
         end
+        if !new_resource.aws_assume_role_arn.to_s.empty? && !new_resource.aws_role_session_name.to_s.empty?
+          Chef::Log.debug("Assuming role #{new_resource.aws_assume_role_arn}")
+          sts_client = ::Aws::STS::Client.new(credentials: creds, region: region)
+          creds = ::Aws::AssumeRoleCredentials.new(client: sts_client, role_arn: new_resource.aws_assume_role_arn, role_session_name: new_resource.aws_role_session_name)
+        end
         aws_interface.new(credentials: creds, region: region)
       end
 

--- a/resources/ebs_raid.rb
+++ b/resources/ebs_raid.rb
@@ -20,6 +20,8 @@ state_attrs :aws_access_key,
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String
 attribute :mount_point,           kind_of: String
 attribute :mount_point_owner,     kind_of: String, default: 'root'
 attribute :mount_point_group,     kind_of: String, default: 'root'

--- a/resources/elastic_ip.rb
+++ b/resources/elastic_ip.rb
@@ -8,5 +8,7 @@ state_attrs :aws_access_key,
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String
 attribute :ip,                    kind_of: String, name_attribute: true
 attribute :timeout,               default: 3 * 60 # 3 mins, nil or 0 for no timeout

--- a/resources/elastic_lb.rb
+++ b/resources/elastic_lb.rb
@@ -6,4 +6,6 @@ state_attrs :aws_access_key,
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String
 attribute :name,                  kind_of: String

--- a/resources/instance_monitoring.rb
+++ b/resources/instance_monitoring.rb
@@ -6,3 +6,5 @@ state_attrs :aws_access_key
 attribute :aws_access_key, kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String

--- a/resources/resource_tag.rb
+++ b/resources/resource_tag.rb
@@ -8,5 +8,7 @@ state_attrs :aws_access_key,
 attribute :aws_access_key, kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
-attribute :resource_id,  kind_of: [String, Array], regex: /(i|snap|vol)-[a-fA-F0-9]{8}/
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String
+attribute :resource_id, kind_of: [String, Array], regex: /(i|snap|vol)-[a-fA-F0-9]{8}/
 attribute :tags, kind_of: Hash, required: true

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -18,6 +18,8 @@ attribute :aws_access_key_id, kind_of: String
 attribute :aws_access_key, kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String
 attribute :owner, regex: Chef::Config[:user_valid_regex]
 attribute :group, regex: Chef::Config[:group_valid_regex]
 attribute :mode, kind_of: [String, NilClass], default: nil

--- a/resources/secondary_ip.rb
+++ b/resources/secondary_ip.rb
@@ -9,6 +9,8 @@ state_attrs :aws_access_key,
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token,     kind_of: String, default: nil
+attribute :aws_assume_role_arn,   kind_of: String
+attribute :aws_role_session_name, kind_of: String
 attribute :ip,                    kind_of: String, default: nil
 attribute :interface,             kind_of: String, default: 'eth0'
 attribute :timeout,               default: 3 * 60 # 3 mins, nil or 0 for no timeout


### PR DESCRIPTION
Adds support to use AssumeRole granted credentials, using the either provided key or an instance profile.

My use case is with s3_file, so I can use a role on another account to gain access to a bucket. I'm less certain of the value for other resources, but I updated all of the resources anyway.

I tested it with s3_file and an instance profile, and it worked fine. 

