### PR TITLE
S3 Conditional Requests

### DIFF
--- a/libraries/s3.rb
+++ b/libraries/s3.rb
@@ -13,6 +13,24 @@ module Opscode
         end
         @@s3 ||= create_aws_interface(::Aws::S3::Client)
       end
+
+      def compare_md5s(remote_object, local_file_path)
+        local_md5 = Digest::MD5.new
+        remote_hash = remote_object.etag
+
+        File.open(local_file_path, 'rb') do |f|
+          f.each_line do |line|
+            local_md5.update line
+          end
+        end
+
+        local_hash = local_md5.hexdigest
+
+        Chef::Log.debug "Remote file md5 hash:  #{remote_hash}"
+        Chef::Log.debug "Local file md5 hash:   #{local_hash}"
+
+        local_hash == remote_hash
+      end
     end
   end
 end

--- a/providers/s3_file.rb
+++ b/providers/s3_file.rb
@@ -30,7 +30,7 @@ def do_s3_file(resource_action)
 
   remote_path = new_resource.remote_path
   remote_path.sub!(%r{^/*}, '')
-  skip_action == false
+  skip_action = false
 
   obj = ::Aws::S3::Object.new(bucket_name: new_resource.bucket, key: remote_path, client: s3)
   s3url = obj.presigned_url(:get, expires_in: 300)
@@ -42,7 +42,7 @@ def do_s3_file(resource_action)
     end
   end
 
-  if not skip_action
+  unless skip_action
     remote_file new_resource.name do
       path new_resource.path
       source s3url.gsub(%r{https://([\w\.\-]*)\.\{1\}s3.amazonaws.com:443}, 'https://s3.amazonaws.com:443/\1') # Fix for ssl cert issue

--- a/providers/s3_file.rb
+++ b/providers/s3_file.rb
@@ -30,31 +30,41 @@ def do_s3_file(resource_action)
 
   remote_path = new_resource.remote_path
   remote_path.sub!(%r{^/*}, '')
+  skip_action == false
 
   obj = ::Aws::S3::Object.new(bucket_name: new_resource.bucket, key: remote_path, client: s3)
   s3url = obj.presigned_url(:get, expires_in: 300)
 
-  remote_file new_resource.name do
-    path new_resource.path
-    source s3url.gsub(%r{https://([\w\.\-]*)\.\{1\}s3.amazonaws.com:443}, 'https://s3.amazonaws.com:443/\1') # Fix for ssl cert issue
-    owner new_resource.owner
-    group new_resource.group
-    mode new_resource.mode
-    checksum new_resource.checksum
-    backup new_resource.backup
-    if node['platform_family'] == 'windows'
-      inherits new_resource.inherits
-      rights new_resource.rights
+  if resource_action == :create
+    if Opscode::Aws::S3.compare_md5s(obj, new_resource.path)
+      Chef::Log.info("Remote and local files appear to be identical, skipping #{resource_action} operation.")
+      skip_action == true
     end
-    action resource_action
+  end
 
-    if version.major > 11 || (version.major == 11 && version.minor >= 6)
-      headers new_resource.headers
-      use_etag new_resource.use_etag
-      use_last_modified new_resource.use_last_modified
-      atomic_update new_resource.atomic_update
-      force_unlink new_resource.force_unlink
-      manage_symlink_source new_resource.manage_symlink_source
+  if not skip_action
+    remote_file new_resource.name do
+      path new_resource.path
+      source s3url.gsub(%r{https://([\w\.\-]*)\.\{1\}s3.amazonaws.com:443}, 'https://s3.amazonaws.com:443/\1') # Fix for ssl cert issue
+      owner new_resource.owner
+      group new_resource.group
+      mode new_resource.mode
+      checksum new_resource.checksum
+      backup new_resource.backup
+      if node['platform_family'] == 'windows'
+        inherits new_resource.inherits
+        rights new_resource.rights
+      end
+      action resource_action
+
+      if version.major > 11 || (version.major == 11 && version.minor >= 6)
+        headers new_resource.headers
+        use_etag new_resource.use_etag
+        use_last_modified new_resource.use_last_modified
+        atomic_update new_resource.atomic_update
+        force_unlink new_resource.force_unlink
+        manage_symlink_source new_resource.manage_symlink_source
+      end
     end
   end
 end

--- a/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
@@ -6,3 +6,11 @@ aws_s3_file '/tmp/an_file' do
   aws_access_key_id node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
 end
+
+# do it again. this will produce an INFO log message and skip the actual action
+aws_s3_file '/tmp/an_file' do
+  bucket node['aws_test']['bucket']
+  remote_path node['aws_test']['s3key']
+  aws_access_key_id node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+end


### PR DESCRIPTION
Adding basic logic for skipping :create when local & remote files match for issue #169 

Wasn't really sure how to set up the kitchen test for this... I duplicated the resource call but that'll pass even if the file is re-uploaded. Thoughts?

Used the method laid out https://github.com/adamsb6/s3_file though greatly simplified. Judging by that library, this likely won't work (ie: will re-upload anyway) if the file is encrypted in S3.