### PR TITLE
set a rubygems source that works in china when in cn-north-1 region.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,8 @@
 chef_gem 'aws-sdk' do
   version node['aws']['aws_sdk_version']
   compile_time true if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
+  source 'https://ruby.taobao.org/' if node['aws']['region'].eql?('cn-north-1')
+  clear_sources true if node['aws']['region'].eql?('cn-north-1')
   action :install
 end
 


### PR DESCRIPTION
getting aws-sdk to install reliably using the default rubygems source is near impossible in cn-north-1.  Using the taobao local mirror works.