### PR TITLE
Added missing Elb module reference to elastic_lb provider

### DIFF
--- a/providers/elastic_lb.rb
+++ b/providers/elastic_lb.rb
@@ -1,4 +1,4 @@
-include Opscode::Aws
+include Opscode::Aws::Elb
 
 use_inline_resources
 


### PR DESCRIPTION
While making necessary changes to update to v3.3.1 (from v2.9.2), I came across the following error across our previously working elb registrations:

    =============================================================
    Error executing action `register` on resource 'aws_elastic_lb[name-of-elb]'
    =============================================================
    
    NameError
    ---------
    No resource, method, or local variable named `elb' for `LWRP provider aws_elastic_lb from cookbook     aws ""'
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/aws/providers/elastic_lb.rb:7:in `block (2 levels) in class_from_file'
    /var/chef/cache/cookbooks/aws/providers/elastic_lb.rb:6:in `block in class_from_file

After some review, it seemed the provider wasn't able to call the Elb module properly in aws/libraries/elb.rb. This fix resolved the issue