### PR TITLE
Pass through retries / retry_delay to remote_file

### DIFF
--- a/providers/s3_file.rb
+++ b/providers/s3_file.rb
@@ -52,6 +52,8 @@ def do_s3_file(resource_action)
     force_unlink new_resource.force_unlink
     manage_symlink_source new_resource.manage_symlink_source
     sensitive new_resource.sensitive
+    retries new_resource.retries
+    retry_delay new_resource.retry_delay
     if node['platform_family'] == 'windows'
       inherits new_resource.inherits
       rights new_resource.rights

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -34,8 +34,8 @@ attribute :atomic_update, kind_of: [TrueClass, FalseClass], default: true
 attribute :force_unlink, kind_of: [TrueClass, FalseClass], default: false
 attribute :manage_symlink_source, kind_of: [TrueClass, FalseClass]
 attribute :sensitive, kind_of: [TrueClass, FalseClass], default: false
-attribute :retries, kind_of: [Integer, FalseClass], default: 0
-attribute :retry_delay, kind_of: [Integer, FalseClass], default: 3
+attribute :retries, kind_of: Integer, default: 0
+attribute :retry_delay, kind_of: Integer, default: 3
 if node['platform_family'] == 'windows'
   attribute :inherits, kind_of: [TrueClass, FalseClass], default: true
   attribute :rights, kind_of: Hash

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -34,6 +34,8 @@ attribute :atomic_update, kind_of: [TrueClass, FalseClass], default: true
 attribute :force_unlink, kind_of: [TrueClass, FalseClass], default: false
 attribute :manage_symlink_source, kind_of: [TrueClass, FalseClass]
 attribute :sensitive, kind_of: [TrueClass, FalseClass], default: false
+attribute :retries, kind_of: [Integer, FalseClass], default: 0
+attribute :retry_delay, kind_of: [Integer, FalseClass], default: 3
 if node['platform_family'] == 'windows'
   attribute :inherits, kind_of: [TrueClass, FalseClass], default: true
   attribute :rights, kind_of: Hash


### PR DESCRIPTION
### Description

Pass through retries / retry_delay to remote_file resource.

Obvious fix

### Issues Resolved

https://github.com/chef-cookbooks/aws/issues/237