### PR TITLE
Retries

### DIFF
--- a/providers/s3_file.rb
+++ b/providers/s3_file.rb
@@ -52,6 +52,7 @@ def do_s3_file(resource_action)
     force_unlink new_resource.force_unlink
     manage_symlink_source new_resource.manage_symlink_source
     sensitive new_resource.sensitive
+    retries new_resource.retries
     if node['platform_family'] == 'windows'
       inherits new_resource.inherits
       rights new_resource.rights

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -22,6 +22,7 @@ attribute :aws_session_token,     kind_of: String
 attribute :aws_assume_role_arn,   kind_of: String
 attribute :aws_role_session_name, kind_of: String
 attribute :region, kind_of: String, default: 'us-east-1' # unless specified this is where your bucket is
+attribute :retries, kind_of: Fixnum, default: 0
 attribute :owner, regex: Chef::Config[:user_valid_regex]
 attribute :group, regex: Chef::Config[:group_valid_regex]
 attribute :mode, kind_of: [String, NilClass]


### PR DESCRIPTION
### Description

Adds retires attribute to the `aws_s3_file` resource provider, and passes it through to `remote_file`.

### Issues Resolved

closes #237

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

