### PR TITLE
Improve "Breaking changes" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This file is used to list changes made in each version of the aws cookbook.
 - Removed the ability to use databags for credentials with the ebs_raid provider. You must now pass the credentials in via the resource, [@tas50]
 - [#218] Remove support for Chef < 11.6.0, [@tas50]
 - Switched to Ohai to gather information on the AWS instance instead of direct AWS metadata calls. This also removes the node['region'] attribute, which is no longer necessary. If you would like to mock the region for some reason in local testing set `node['ec2']['placement_availability_zone']` to the AZ, as this is used to determine the region, [@tas50]
+- aws-sdk gem is no longer loaded in default recipe
 
 ### Other Changes
 


### PR DESCRIPTION
### Description

Improve "Breaking changes" section to clearly say that this cookbook is no longer load the aws-sdk gem.
This does have any impact in this cookbook, but users that use this cookbook can be impacted.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


