### PR TITLE
Adding "instance_tags" helper method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ end
 
 ### default.rb
 
-This recipe is empty. In previous releases it installed the aws-sdk gem, but this is now performed automatically in the providers.
+This recipe includes an `instance_tags` helper method, which returns a dictionary of all the instance's AWS Resource tags. In previous releases it installed the aws-sdk gem, but this is now performed automatically in the providers.
 
 ### ec2_hints.rb
 

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -62,7 +62,7 @@ module Opscode
       # Priority: resource property, user set node attribute -> ohai data -> us-east-1
       def aws_region
         # facilitate support for region in resource name
-        if new_resource.region
+        if (defined? new_resource) && new_resource.region
           Chef::Log.debug("Using overridden region name, #{new_resource.region}, from resource")
           new_resource.region
         elsif node.attribute?('ec2')
@@ -80,7 +80,7 @@ module Opscode
       def create_aws_interface(aws_interface)
         aws_interface_opts = { region: aws_region }
 
-        if !new_resource.aws_access_key.to_s.empty? && !new_resource.aws_secret_access_key.to_s.empty?
+        if (defined? new_resource) && !new_resource.aws_access_key.to_s.empty? && !new_resource.aws_secret_access_key.to_s.empty?
           Chef::Log.debug('Using resource-defined credentials')
           aws_interface_opts[:credentials] = ::Aws::Credentials.new(
             new_resource.aws_access_key,
@@ -90,7 +90,7 @@ module Opscode
           Chef::Log.debug('Using local credential chain')
         end
 
-        if !new_resource.aws_assume_role_arn.to_s.empty? && !new_resource.aws_role_session_name.to_s.empty?
+        if (defined? new_resource) &&  !new_resource.aws_assume_role_arn.to_s.empty? && !new_resource.aws_role_session_name.to_s.empty?
           Chef::Log.debug("Assuming role #{new_resource.aws_assume_role_arn}")
           sts_client = ::Aws::STS::Client.new(region: aws_region,
                                               access_key_id: new_resource.aws_access_key,

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -90,7 +90,7 @@ module Opscode
           Chef::Log.debug('Using local credential chain')
         end
 
-        if (defined? new_resource) &&  !new_resource.aws_assume_role_arn.to_s.empty? && !new_resource.aws_role_session_name.to_s.empty?
+        if (defined? new_resource) && !new_resource.aws_assume_role_arn.to_s.empty? && !new_resource.aws_role_session_name.to_s.empty?
           Chef::Log.debug("Assuming role #{new_resource.aws_assume_role_arn}")
           sts_client = ::Aws::STS::Client.new(region: aws_region,
                                               access_key_id: new_resource.aws_access_key,

--- a/libraries/tag_helper.rb
+++ b/libraries/tag_helper.rb
@@ -1,0 +1,16 @@
+module Opscode
+  module Aws
+    module Helpers
+      include Opscode::Aws::Ec2
+      def instance_tags
+        if @instance_tags.nil?
+          @instance_tags = {}
+          ec2.describe_tags(filters: [{ name: 'resource-id', values: [instance_id] }])[:tags].map do |tag|
+            @instance_tags[tag[:key]] = tag[:value]
+          end
+        end
+        @instance_tags
+      end
+    end
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,7 @@
-# This cookbook is no longer needed to load the aws-sdk and can be removed
-# from node run_lists without any impact
+# This recipe is no longer needed to load the aws-sdk.
+# Adding this recipe in the run_list will include a helper method
+# called "instance_tags" which retuns a dictionary the current
+# AWS Resoruce Tags configured for the node.
 
-Chef::Log.warn('The default aws recipe does nothing. See the readme for information on using the aws resources')
+::Chef::Recipe.send(:include, Opscode::Aws::Helpers)
+Chef::Log.warn('The default aws recipe does nothing except include helper methods. See the readme for information on using the aws resources')


### PR DESCRIPTION
### Description

Adding & exposing an "instance_tags" helper method, which returns a dictionary of the node's AWS Resource Tags.
### Issues Resolved
#95
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

libraries/ec2.rb changes are to ensure that the chain of underlying
method calls don’t reference an undefined object when called from a
recipe context.

reciples/default.rb modified to automagically include the module so
that the method is available for use in recipes.
