### PR TITLE
add matcher definitions in matchers.rb

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -158,3 +158,9 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:aws_secondary_ip, :assign, resource_name)
   end
 end
+
+resources = %i(aws_cloudformation_stack aws_dynamodb_table aws_ebs_raid aws_ebs_volume aws_elastic_ip aws_elastic_lb aws_iam_group aws_iam_policy aws_iam_role aws_iam_user aws_instance_monitoring aws_kinetic_stream aws_resource_tag aws_s3_file aws_secondary_ip)
+
+resources.each do |resource|
+  ChefSpec.define_matcher resource
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -157,10 +157,11 @@ if defined?(ChefSpec)
   def assign_aws_secondary_ip(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:aws_secondary_ip, :assign, resource_name)
   end
+
+  resources = %i(aws_cloudformation_stack aws_dynamodb_table aws_ebs_raid aws_ebs_volume aws_elastic_ip aws_elastic_lb aws_iam_group aws_iam_policy aws_iam_role aws_iam_user aws_instance_monitoring aws_kinetic_stream aws_resource_tag aws_s3_file aws_secondary_ip)
+
+  resources.each do |resource|
+    ChefSpec.define_matcher resource
+  end
 end
 
-resources = %i(aws_cloudformation_stack aws_dynamodb_table aws_ebs_raid aws_ebs_volume aws_elastic_ip aws_elastic_lb aws_iam_group aws_iam_policy aws_iam_role aws_iam_user aws_instance_monitoring aws_kinetic_stream aws_resource_tag aws_s3_file aws_secondary_ip)
-
-resources.each do |resource|
-  ChefSpec.define_matcher resource
-end


### PR DESCRIPTION
### Description

This allows the resources to be used with notification tests like so:

```ruby
let(:download) { chef_run.aws_s3_file('my_file') }

it 'notifies something' do 
  expect(download).to notify('execute[something]').immediately
end
```

I ran into a problem when I was trying to do this in a cookbook that is wrapping `aws`.

I ran into some trouble running the tests but just thought I'd see whether this is something the maintainers are interested in adding before continuing. Not sure if this is the kind of thing that needs to be tested or added to the README. Could also move the code somewhere else if preferred!  

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


