### PR TITLE
Dont declare region twice for aws_s3_file

### DIFF
--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -20,7 +20,6 @@ attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token, kind_of: String
 attribute :aws_assume_role_arn, kind_of: String
 attribute :aws_role_session_name, kind_of: String
-attribute :region, kind_of: String, default: 'us-east-1' # unless specified this is where your bucket is
 attribute :owner, regex: Chef::Config[:user_valid_regex]
 attribute :group, regex: Chef::Config[:group_valid_regex]
 attribute :mode, kind_of: [String, NilClass]


### PR DESCRIPTION
### Description

Region default for `aws_s3_file` should be set to `nil` so the EC2 library will try use the metadata service first, before defaulting to `us-east-1`. The region attribute is already set like so in a few lines above, and the other ec2 like resources are already like this, so I think that was the intended behaviour all along.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

