### PR TITLE
Add ec2:ModifyInstanceAttribute to sample IAM policy (fixes #241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Of course, the instance role must have the required policies. Here is a sample p
       "Action": [
         "ec2:AttachVolume",
         "ec2:CreateVolume",
+        "ec2:ModifyInstanceAttribute",
         "ec2:ModifyVolumeAttribute",
         "ec2:DescribeVolumeAttribute",
         "ec2:DescribeVolumeStatus",


### PR DESCRIPTION
### Description

Fixes the sample IAM policy so that it can be used for all standard variations of `aws_ebs_volume`

### Issues Resolved

#241 - Documentation: delete_on_termination requires ec2:ModifyInstanceAttribute
