### PR TITLE
If region is not specified, let's look up the bucket's region.

### DIFF
--- a/libraries/s3.rb
+++ b/libraries/s3.rb
@@ -10,6 +10,23 @@ module Opscode
 
         Chef::Log.debug('Initializing the S3 Client')
         @s3 ||= create_aws_interface(::Aws::S3::Client)
+
+        if new_resource.region.nil? && @s3_region.nil?
+          @s3_region ||= query_bucket_region
+          @s3 = create_aws_interface(::Aws::S3::Client)
+        end
+        @s3
+      end
+
+      def query_bucket_region
+        location_constraint = @s3.get_bucket_location(bucket: new_resource.bucket).location_constraint
+        region = location_constraint == '' ? 'us-east-1' : location_constraint
+        Chef::Log.debug("Bucket #{new_resource.bucket} is located in region #{region}")
+        region
+      end
+
+      def aws_region
+        @s3_region || super
       end
 
       def s3_obj


### PR DESCRIPTION

### Description

[Describe what this change achieves]
This change allows for the S3 bucket region to be automatically detected; it uses the SDK to poll for the bucket region instead of needing to specify it, and simplifies workflows accordingly.

### Issues Resolved

For example, when running this cookbook before this change from a node in us-west-2, `s3_file` choked on a bucket in `us-east-1`.  The `region` parameter was not set (and was not easily done due to `s3_file` being used on a wrapped cookbook).  AWS returned a 301, but those redirects cannot be followed (due to signatures not being valid across regions); a new request must instead be made.  This change would allow for the `region` parameter to be omitted.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
