### PR TITLE
Let the API decide what the default volume type is

### DIFF
--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -174,9 +174,11 @@ def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, pi
   availability_zone ||= instance_availability_zone
 
   # Sanity checks so we don't shoot ourselves.
-  raise "Invalid volume type: #{volume_type}" unless %w(standard io1 gp2 sc1 st1).include?(volume_type)
+  raise "Invalid volume type: #{volume_type}" if volume_type && !%w(standard io1 gp2 sc1 st1).include?(volume_type)
 
-  params = { availability_zone: availability_zone, volume_type: volume_type, encrypted: encrypted, kms_key_id: kms_key_id }
+  params = { availability_zone: availability_zone, encrypted: encrypted, kms_key_id: kms_key_id }
+  params['volume_type'] = volume_type if volume_type
+
   # PIOPs requested. Must specify an iops param and probably won't be "low".
   if volume_type == 'io1'
     raise 'IOPS value not specified.' unless piops >= 100

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -31,7 +31,7 @@ attribute :volume_id,             kind_of: String
 attribute :description,           kind_of: String
 attribute :timeout,               default: 3 * 60 # 3 mins, nil or 0 for no timeout
 attribute :snapshots_to_keep,     default: 2
-attribute :volume_type,           kind_of: String, default: 'standard'
+attribute :volume_type,           kind_of: String
 attribute :piops,                 kind_of: Integer, default: 0
 attribute :encrypted,             kind_of: [TrueClass, FalseClass], default: false
 attribute :kms_key_id,            kind_of: String

--- a/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
@@ -1,16 +1,34 @@
-aws_ebs_volume 'db_ebs_volume' do
+aws_ebs_volume 'ssd_ebs_volume' do
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
   size 1
   device '/dev/sdi'
   delete_on_termination true
   action [:create, :attach]
+  volume_type 'gp2' # test that specifying type works
 end
 
-aws_ebs_volume 'db_ebs_volume' do
+aws_ebs_volume 'standard_ebs_vol' do
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  size 1
+  device '/dev/sdj'
+  delete_on_termination true
+  action [:create, :attach]
+end
+
+aws_ebs_volume 'ssd_ebs_volume' do
   action [:detach]
 end
 
-aws_ebs_volume 'db_ebs_volume' do
+aws_ebs_volume 'ssd_ebs_volume' do
+  action [:delete]
+end
+
+aws_ebs_volume 'standard_ebs_vol' do
+  action [:detach]
+end
+
+aws_ebs_volume 'standard_ebs_vol' do
   action [:delete]
 end


### PR DESCRIPTION
In testing this it’s still standard though.

Signed-off-by: Tim Smith <tsmith@chef.io>