### PR TITLE
Fix for Issue #283 (error on aws_resource_tag)

### DIFF
--- a/providers/resource_tag.rb
+++ b/providers/resource_tag.rb
@@ -77,7 +77,7 @@ action :force_remove do
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::AwsResourceTag.new(@new_resource.name)
+  @current_resource = Chef::ResourceResolver.resolve(:aws_resource_tag).new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   if @new_resource.resource_id
     @current_resource.resource_id(@new_resource.resource_id)


### PR DESCRIPTION
Fix for Issue #283 (error on aws_resource_tag): Updated deprecated Chef::Resource call with valid Chef::ResourceResolver drop-in

Signed-off-by: Chris Hayes <chayes@cactuspowered.com>

### Description

aws_resource_tag looks to be referencing Chef::Resource in the provider, which is fully deprecated in Chef 13. Per this [Chef blog post](https://blog.chef.io/2015/06/24/chef-client-12-4-0-released/) (very bottom), a drop-in replacement is provided. This pull request implements the valid replacement.

### Issues Resolved

#283 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
