### PR TITLE
Add aws_s3_bucket resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -78,7 +78,7 @@ suites:
       aws_test:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-        bucket: <%= ENV['AWS_S3_BUCKET'] || 'aws-cookbook' %>
+        bucket: <%= ENV['AWS_S3_BUCKET'] || 'aws-cookbook-2' %>
         bucket_west: <%= ENV['AWS_S3_BUCKET_WEST'] || 'aws-cookbook-west' %>
         s3key: <%= ENV['AWS_S3_KEY'] || 'a_file' %>
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This cookbook provides resources for configuring and managing nodes running in A
 - Kinesis Stream Management (`kinesis_stream`)
 - Resource Tags (`resource_tag`)
 - S3 Files (`s3_file`)
+- S3 Buckets (`s3_bucket`)
 - Secondary IPs (`secondary_ip`)
 
 Unsupported AWS resources that have other cookbooks include but are not limited to:
@@ -226,7 +227,7 @@ Use this resource to manage CloudWatch alarms.
 
 #### Properties:
 
-- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - passed to `AwsCookbook:Ec2` to authenticate, required, unless using IAM roles for authentication.
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `alarm_name` - the alarm name. If none is given on assignment, will take the resource name.
 - `alarm_description` - the description of alarm. Can be blank also.
 - `actions_enabled` - true for enable action on OK, ALARM or Insufficient data. if true, any of ok_actions, alarm_actions or insufficient_data_actions must be specified.
@@ -303,7 +304,7 @@ Manage Elastic Block Store (EBS) volumes with this resource.
 
 #### Properties:
 
-- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - passed to `AwsCookbook:Ec2` to authenticate, required, unless using IAM roles for authentication.
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `ip` - the IP address.
 - `timeout` - connection timeout for EC2 API.
 
@@ -318,7 +319,7 @@ Adds or removes nodes to an Elastic Load Balancer
 
 #### Properties:
 
-- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - passed to `AwsCookbook:Ec2` to authenticate, required, unless using IAM roles for authentication.
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `name` - the name of the LB, required.
 
 ### aws_instance_monitoring
@@ -338,7 +339,7 @@ aws_instance_monitoring "enable detailed monitoring"
 
 #### Properties:
 
-- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - passed to `AwsCookbook:Ec2` to authenticate, required, unless using IAM roles for authentication.
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 
 ### aws_ebs_volume
 
@@ -442,6 +443,13 @@ end
 
 `s3_file` can be used to download a file from s3 that requires aws authorization. This is a wrapper around the core chef `remote_file` resource and supports the same resource attributes as `remote_file`. See [remote_file Chef Docs] (<https://docs.chef.io/resource_remote_file.html>) for a complete list of available attributes.
 
+#### Actions:
+
+- `create`: Downloads a file from s3
+- `create_if_missing`: Downloads a file from S3 only if it doesn't exist locally
+- `delete`: Deletes a local file
+- `touch`: Touches a local file
+
 #### Example:
 
 ```ruby
@@ -451,6 +459,43 @@ aws_s3_file '/tmp/foo' do
   aws_access_key aws['aws_access_key_id']
   aws_secret_access_key aws['aws_secret_access_key']
   region 'us-west-1'
+end
+```
+
+### aws_s3_bucket
+
+`s3_bucket` can be used to create or delete S3 buckets. Note that buckets can only be deleted if they are empty unless you specify `delete_all_objects` true, which will delete EVERYTHING in your bucket first.
+
+#### Actions:
+
+- `create`: Creates the bucket
+- `delete`: Deletes the bucket
+
+#### Properties:
+
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
+- `region` - The AWS region containing the bucket. Default: The current region of the node when running in AWS or us-east-1 if the node is not in AWS.
+- `versioning` - Enable or disable S3 bucket versioning. Default: false
+- `delete_all_objects` - Used with the `:delete` action to delete all objects before deleting a bucket. Use with EXTREME CAUTION. default: false (for a reason)
+
+#### Example:
+
+```ruby
+aws_s3_bucket 'some-unique-name' do
+  aws_access_key aws['aws_access_key_id']
+  aws_secret_access_key aws['aws_secret_access_key']
+  versioning true
+  region 'us-west-1'
+  action :create
+end
+```
+
+```ruby
+aws_s3_bucket 'another-unique-name' do
+  aws_access_key aws['aws_access_key_id']
+  aws_secret_access_key aws['aws_secret_access_key']
+  region 'us-west-1'
+  action :delete
 end
 ```
 
@@ -768,7 +813,7 @@ end
 
 #### Properties:
 
-- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - passed to `AwsCookbook:Ec2` to authenticate, required, unless using IAM roles for authentication.
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `tags` - a hash of key value pairs to be used as resource tags, (e.g. `{ "Name" => "foo", "Environment" => node.chef_environment }`,) required.
 - `resource_id` - resources whose tags will be modified. The value may be a single ID as a string or multiple IDs in an array. If no
 - `resource_id` is specified the name attribute will be used.
@@ -784,7 +829,7 @@ This feature is available only to instances in EC2-VPC. It allows you to assign 
 
 #### Properties:
 
-- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - passed to `AwsCookbook:Ec2` to authenticate, required, unless using IAM roles for authentication.
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `ip` - the private IP address. If none is given on assignment, will assign a random IP in the subnet.
 - `interface` - the network interface to assign the IP to. If none is given, uses the default interface.
 - `timeout` - connection timeout for EC2 API.

--- a/providers/dynamodb_table.rb
+++ b/providers/dynamodb_table.rb
@@ -163,7 +163,6 @@ private
 def do_delete_table
   converge_by("delete DynamoDB table #{new_resource.table_name}") do
     dynamodb.delete_table(table_name: new_resource.table_name)
-    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -181,7 +180,6 @@ def do_create_table
       provisioned_throughput: new_resource.provisioned_throughput,
       stream_specification: new_resource.stream_specification
     )
-    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -196,7 +194,6 @@ def do_update_throughput
       table_name: new_resource.table_name,
       provisioned_throughput: new_resource.provisioned_throughput
     )
-    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -211,7 +208,6 @@ def do_update_streamspec
       table_name: new_resource.table_name,
       stream_specification: new_resource.stream_specification
     )
-    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -230,7 +226,6 @@ def do_change_gsi(op)
         attribute_definitions: new_resource.attribute_definitions,
         global_secondary_index_updates: [index]
       )
-      new_resource.updated_by_last_action(true)
     end
   end
 end

--- a/resources/cloudformation_stack.rb
+++ b/resources/cloudformation_stack.rb
@@ -22,19 +22,15 @@ action :create do
     # only update if stack changed
     if cfn_stack_changed? || cfn_params_chagned?
       converge_by("update stack #{new_resource.stack_name}") do
-        Chef::Log.debug("update stack #{new_resource.stack_name}")
         options = build_cfn_options
         options.delete(:disable_rollback)
         cfn.update_stack(options)
-        new_resource.updated_by_last_action(true)
       end
     end
   else
     converge_by("create stack #{new_resource.stack_name}") do
-      Chef::Log.debug("create stack #{new_resource.stack_name}")
       options = build_cfn_options
       cfn.create_stack(options)
-      new_resource.updated_by_last_action(true)
     end
   end
 end
@@ -42,9 +38,7 @@ end
 action :delete do
   if stack_exists?(new_resource.stack_name)
     converge_by("delete stack #{new_resource.stack_name}") do
-      Chef::Log.debug("delete stack #{new_resource.stack_name}")
       cfn.delete_stack(stack_name: new_resource.stack_name)
-      new_resource.updated_by_last_action(true)
     end
   end
 end

--- a/resources/iam_group.rb
+++ b/resources/iam_group.rb
@@ -30,7 +30,6 @@ action :create do
             group_name: new_resource.group_name,
             policy_arn: policy.policy_arn
           )
-          new_resource.updated_by_last_action(true)
         end
       end
       # remove policies that are present from the new policies to add
@@ -41,14 +40,12 @@ action :create do
     # add any leftover new policies if they exist.
     unless new_policies.empty?
       converge_by("attach new policies to group #{new_resource.group_name}: #{new_policies.join(',')}") do
-        Chef::Log.debug("attach new policies to group #{new_resource.group_name}: #{new_policies.join(',')}")
         new_policies.each do |policy|
           iam.attach_group_policy(
             group_name: new_resource.group_name,
             policy_arn: policy
           )
         end
-        new_resource.updated_by_last_action(true)
       end
     end
     # USERS
@@ -59,12 +56,10 @@ action :create do
       # delete removed users if new_resource.remove_members == true
       if !new_resource.members.include?(user.user_name) && new_resource.remove_members == true
         converge_by("remove user #{user.user_name} from group #{new_resource.group_name}") do
-          Chef::Log.debug("remove user #{user.user_name} from group #{new_resource.group_name}")
           iam.remove_user_from_group(
             group_name: new_resource.group_name,
             user_name: user.user_name
           )
-          new_resource.updated_by_last_action(true)
         end
       end
       # remove users that are present from the new users to add
@@ -75,19 +70,16 @@ action :create do
     # add any leftover new policies if they exist.
     unless new_users.empty?
       converge_by("add new users to group #{new_resource.group_name}: #{new_users.join(',')}") do
-        Chef::Log.debug("add new users to group #{new_resource.group_name}: #{new_users.join(',')}")
         new_users.each do |user|
           iam.add_user_to_group(
             group_name: new_resource.group_name,
             user_name: user.to_s
           )
         end
-        new_resource.updated_by_last_action(true)
       end
     end
   else
     converge_by("add new group #{new_resource.group_name}") do
-      Chef::Log.debug("add new group #{new_resource.group_name}")
       iam.create_group(
         path: new_resource.path,
         group_name: new_resource.group_name
@@ -106,7 +98,6 @@ action :create do
           policy_arn: policy
         )
       end
-      new_resource.updated_by_last_action(true)
     end
   end
 end
@@ -114,7 +105,6 @@ end
 action :delete do
   if group_exists?(new_resource.group_name)
     converge_by("delete group #{new_resource.group_name}") do
-      Chef::Log.debug("delete group #{new_resource.group_name}")
       # un-attach associated entities (users, policies)
       resp = iam.get_group(group_name: new_resource.group_name)
       resp.users.each do |user|
@@ -132,7 +122,6 @@ action :delete do
       end
       # delete the group
       iam.delete_group(group_name: new_resource.group_name)
-      new_resource.updated_by_last_action(true)
     end
   end
 end

--- a/resources/s3_bucket.rb
+++ b/resources/s3_bucket.rb
@@ -1,0 +1,87 @@
+property :name, String, name_property: true
+property :region, String, default: lazy { aws_region }
+property :delete_all_objects, [true, false], default: false
+property :versioning, [true, false], default: false, desired_state: false
+
+# aws credential/connection attributes
+property :aws_access_key, String
+property :aws_secret_access_key, String
+property :aws_session_token, String
+property :aws_assume_role_arn, String
+property :aws_role_session_name, String
+
+include AwsCookbook::Ec2 # needed for aws_region helper
+
+action :create do
+  if s3_bucket.exists?
+    unless new_resource.versioning == versioning_enabled?
+      desired_state = new_resource.versioning ? 'Enabled' : 'Disabled'
+      update_versioning_status(desired_state)
+    end
+  else # create the bucket from scratch
+    converge_by "create S3 bucket #{new_resource.name}" do
+      s3_bucket.create(new_resource.name)
+      s3_bucket.wait_until_exists
+    end
+  end
+end
+
+action :delete do
+  if s3_bucket.exists?
+    begin
+      if new_resource.delete_all_objects
+        converge_by "delete S3 bucket #{new_resource.name} and all containing objects" do
+          s3_bucket.delete!
+          s3_bucket.wait_until_not_exists
+        end
+      else
+        converge_by "delete S3 bucket #{new_resource.name}" do
+          begin
+            s3_bucket.delete
+            s3_bucket.wait_until_not_exists
+          rescue Aws::S3::Errors::BucketNotEmpty
+            raise "S3 bucket #{new_resource.name} is not empty. If you are ABSOLUTELY SURE you want to delete the bucket and everything in it set delete_all_objects to true"
+          end
+        end
+      end
+    rescue Aws::S3::Errors::PermanentRedirect
+      raise "Permanent redirect received from AWS attempting to delete bucket #{new_resource.name}. This generally means you have the region of the bucket wrong"
+    end
+  else
+    Chef::Log.info("S3 bucket #{new_resource.name} not found so not deleted")
+  end
+end
+
+action_class do
+  include AwsCookbook::Ec2
+
+  def versioning_enabled?
+    v_data = s3_client.get_bucket_versioning(bucket: new_resource.name)
+    v_data.status == 'Enabled' ? true : false
+  end
+
+  def update_versioning_status(state)
+    converge_by("set #{new_resource.name} versioning to #{state}") do
+      s3_client.put_bucket_versioning(bucket: new_resource.name,
+                                      versioning_configuration: {
+                                        status: state,
+                                      })
+    end
+  end
+
+  def s3_client
+    @s3_client ||= begin
+      require 'aws-sdk'
+      Chef::Log.debug('Initializing Aws::S3::Client')
+      create_aws_interface(::Aws::S3::Client, new_resource.region)
+    end
+  end
+
+  def s3_bucket
+    @s3_bucket ||= begin
+      require 'aws-sdk'
+      Chef::Log.debug('Initializing Aws::S3::Bucket')
+      ::Aws::S3::Bucket.new(new_resource.name, client: s3_client)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
@@ -1,3 +1,26 @@
+aws_s3_bucket 'create test bucket' do
+  name 'this-better-be-unique-chef-aws'
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  region 'us-west-2'
+end
+
+aws_s3_bucket 'turn on versioning' do
+  name 'this-better-be-unique-chef-aws'
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  versioning true
+end
+
+aws_s3_bucket 'delete test bucket' do
+  name 'this-better-be-unique-chef-aws'
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  region 'us-west-2'
+  delete_all_objects true # delete the bucket if it's not empty
+  action :delete
+end
+
 aws_s3_file '/tmp/a_file' do
   bucket node['aws_test']['bucket']
   remote_path node['aws_test']['s3key']


### PR DESCRIPTION
What we get here:

s3_bucket resource with `create` and `delete` actions.

Why we need this?

Multiple reasons. The selfish one is we need to be able to create buckets in order to properly test s3_file. This is really just an ends to better s3_file testings. Users probably want this as well. Wanna save logs per environment on your XYZ server. You could use this to make sure that bucket exists with the proper setup and avoid doing it by hand or in tech foo.
