### PR TITLE
Cleanup to the elastic_ip resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,7 @@ suites:
       aws_test:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+
   - name: dynamo_table
     run_list:
     - recipe[aws_test::dynamodb_table]
@@ -53,7 +54,7 @@ suites:
       aws_test:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-        elastic_ip: <%= ENV['AWS_ELASTIC_IP'] %>
+        elastic_ip: <%= ENV['AWS_ELASTIC_IP'] || '34.208.130.166' %>
 
   - name: elb
     run_list:

--- a/README.md
+++ b/README.md
@@ -308,6 +308,19 @@ Manage Elastic Block Store (EBS) volumes with this resource.
 - `ip` - the IP address.
 - `timeout` - connection timeout for EC2 API.
 
+#### Example:
+
+```ruby
+aws_elastic_ip '34.15.30.10' do
+  action :allocate
+end
+
+aws_elastic_ip 'Server public IP' do
+  ip '34.15.30.11'
+  action :allocate
+end
+```
+
 ### aws_elastic_lb
 
 Adds or removes nodes to an Elastic Load Balancer

--- a/resources/elastic_ip.rb
+++ b/resources/elastic_ip.rb
@@ -19,6 +19,11 @@ action :associate do
   else
     converge_by("attach Elastic IP #{ip} to the instance") do
       attach(ip, new_resource.timeout)
+
+      ohai 'Reload Ohai EC2 data' do
+        action :reload
+        plugin 'ec2'
+      end
     end
   end
 end
@@ -33,6 +38,11 @@ action :disassociate do
   else
     converge_by("detach Elastic IP #{ip} from the instance") do
       detach(ip, new_resource.timeout)
+
+      ohai 'Reload Ohai EC2 data' do
+        action :reload
+        plugin 'ec2'
+      end
     end
   end
 end


### PR DESCRIPTION
Add examples to the readme
Remove storage of IP information on the node using the resource name. It's a bad idea to use the node as a persistent store for infrastructure that costs you by the hour. This will burn you at some point
Remove the undocumented allocate action that requires storing IP information on the node
Reload Ohai EC2 plugin data after adding / removing IPs