### PR TITLE
WIP: Add aws_route53_zone resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -122,9 +122,9 @@ suites:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
 
-  - name: route53_record
+  - name: route53
     run_list:
-    - recipe[aws_test::route53_record]
+    - recipe[aws_test::route53]
     attributes:
       aws_test:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Unsupported AWS resources that have other cookbooks include but are not limited 
 
 In order to manage AWS components, authentication credentials need to be available to the node. There are 3 ways to handle this:
 
-1. explicitly pass credentials parameter to the resource
-2. use the credentials in the `~/.aws/credentials` file
-3. let the resource pick up credentials from the IAM role assigned to the instance
+1. Explicitly set the credentials when using the resources
+2. Use the credentials in the `~/.aws/credentials` file
+3. Let the resource pick up credentials from the IAM role assigned to the instance
 
 **Also new** resources can now assume an STS role, with support for MFA as well. Instructions are below in the relevant section.
 
@@ -97,7 +97,7 @@ Note that this also accepts other profiles if they are supplied via the `ENV['AW
 
 If your instance has an IAM role, then the credentials can be automatically resolved by the cookbook using Amazon instance metadata API.
 
-You can then omit the resource parameters `aws_secret_access_key` and `aws_access_key`.
+You can then omit the authentication properties `aws_secret_access_key` and `aws_access_key` when using the resource.
 
 Of course, the instance role must have the required policies. Here is a sample policy for EBS volume management:
 
@@ -822,11 +822,12 @@ end
 
 #### Actions:
 
-- `:create`
-- `:delete`
+- `create` - Create a Route53 record
+- `delete` - Remove a Route53 record
 
 #### Properties:
 
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `name` Required. String. - name of the domain or subdomain.
 - `value` String Array - value appropriate to the `type`.. for type 'A' value would be an IP address in IPv4 format for example.
 - `type` Required. String [DNS record type](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html)
@@ -839,9 +840,7 @@ end
 - `geo_location_subdivision` String
 - `set_identifier` String
 - `zone_id` String
-- `aws_access_key_id` String
-- `aws_secret_access_key` String
-- `aws_region` String default: 'us-east-1'
+- `region` String
 - `overwrite` [true, false] default: true
 - `alias_target` Optional. Hash. - [Associated with Amazon 'alias' type records. The hash contents varies depending on the type of target the alias points to.](http://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html)
 - `mock` [true, false] default: false

--- a/resources/route53_record.rb
+++ b/resources/route53_record.rb
@@ -72,11 +72,9 @@ end
 action_class do
   include AwsCookbook::Ec2
 
+  # convert the passed name to the trailing period format
   def name
-    @name ||= begin
-      return new_resource.name + '.' if new_resource.name !~ /\.$/
-      new_resource.name
-    end
+    @name ||= new_resource.name[-1] == '.' ? new_resource.name : "#{new_resource.name}."
   end
 
   def value

--- a/resources/route53_zone.rb
+++ b/resources/route53_zone.rb
@@ -1,0 +1,67 @@
+property :name, String, required: true, name_property: true
+property :description, String
+property :private, [true, false], default: false
+property :vpc_id, String
+
+# authentication
+property :aws_access_key,        String
+property :aws_secret_access_key, String
+property :aws_session_token,     String
+property :aws_assume_role_arn,   String
+property :aws_role_session_name, String
+property :region,                String, default: lazy { fallback_region }
+
+include AwsCookbook::Ec2 # needed for aws_region helper
+
+action :create do
+  unless zone_exists?(zone_name)
+    converge_by("create zone #{zone_name}") do
+      require 'time'
+      # standard zone values assuming we're not private
+      request_data = {
+        name: zone_name,
+        hosted_zone_config: {
+          comment: new_resource.description,
+          private_zone: false,
+        },
+        caller_reference: Time.now.to_s
+      }
+
+      # add private values if we're private
+      if new_resource.private
+        request_data['hosted_zone_config']['private_zone'] = true
+        request_data['vpc'] = { vpc_id: new_resource.vpc_id }
+      end
+
+      route53_client.create_hosted_zone(request_data)
+    end
+  end
+end
+
+action :delete do
+end
+
+action_class do
+  include AwsCookbook::Ec2
+
+  # convert the passed name to the trailing period format
+  def zone_name
+    @name ||= new_resource.name[-1] == '.' ? new_resource.name : "#{new_resource.name}."
+  end
+
+  # see if the zone exists in the aws account.
+  # we're passing the name and then selecting on it because we want
+  # a small response from AWS, but if the name isn't found AWS returns
+  # everything so we have to find it ourselves
+  def zone_exists?(name)
+    route53_client.list_hosted_zones_by_name(dns_name: name).hosted_zones.select { |r| r.name == name }.any?
+  end
+
+  def route53_client
+    @route53 ||= begin
+      require 'aws-sdk'
+      Chef::Log.debug('Initializing Aws::Route53::Client')
+      create_aws_interface(::Aws::Route53::Client, region: new_resource.region)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/aws_test/recipes/route53.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/route53.rb
@@ -12,6 +12,12 @@ node.default['records']['alias_record']['alias_target']['evaluate_target_health'
 node.default['records']['alias_record']['type'] = 'A'
 node.default['records']['alias_record']['run'] = true
 
+aws_route53_zone 'testkitchen.dmz' do
+  description 'A test zone created by Test Kitchen. Delete anytime.'
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+end
+
 aws_route53_record node['records']['generic_record']['name'] do
   value                 node['records']['generic_record']['value']
   type                  node['records']['generic_record']['type']


### PR DESCRIPTION
This allows you to create / delete a public or private Route53 Zone. It's needed so we can test DNS entries with a real converge and not the mocked converge