### PR TITLE
Refactor secondary_ip and move helpers out of EC2 library

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -146,3 +146,11 @@ suites:
           metric_name: <%= ENV['CLOUDWATCH_METRIC_NAME'] %>
           namespace: <%= ENV['CLOUDWATCH_NAMESPACE'] %>
           statistic: <%= ENV['CLOUDWATCH_STATISTIC'] %>
+
+  - name: secondary_ip
+    run_list:
+    - recipe[aws_test::secondary_ip]
+    attributes:
+      aws_test:
+        key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+        access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ end
 
 ### aws_secondary_ip.rb
 
-This feature is available only to instances in EC2-VPC. It allows you to assign multiple private IP addresses to a network interface.
+This feature is available only to instances within VPCs. It allows you to assign multiple private IP addresses to a network interface.
 
 #### Actions:
 

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -95,33 +95,5 @@ module AwsCookbook
       Chef::Log.debug("Initializing interface with client interface options: #{aws_interface_opts}")
       aws_interface.new(aws_interface_opts)
     end
-
-    # fetch the mac address of an interface.
-    def query_mac_address(interface)
-      node['network']['interfaces'][interface]['addresses'].select do |_, e|
-        e['family'] == 'lladdr'
-      end.keys.first.downcase
-    end
-
-    # fetch the private IP address of an interface from the metadata endpoint.
-    def query_default_interface
-      Chef::Log.debug("Default instance ID is #{node['network']['default_interface']}")
-      node['network']['default_interface']
-    end
-
-    def query_private_ip_addresses(interface)
-      mac = query_mac_address(interface)
-      ip_addresses = open("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/local-ipv4s", proxy: false) { |f| f.read.split("\n") }
-      Chef::Log.debug("#{interface} assigned local ipv4s addresses is/are #{ip_addresses.join(',')}")
-      ip_addresses
-    end
-
-    # fetch the network interface ID of an interface from the metadata endpoint
-    def query_network_interface_id(interface)
-      mac = query_mac_address(interface)
-      eni_id = open("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/interface-id", { proxy: false }, &:gets)
-      Chef::Log.debug("#{interface} eni id is #{eni_id}")
-      eni_id
-    end
   end
 end

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'open-uri'
 
 module AwsCookbook
   module Ec2

--- a/resources/route53_record.rb
+++ b/resources/route53_record.rb
@@ -1,7 +1,6 @@
 provides :aws_route53_record
 provides :route53_record # for compatibility with the old cookbook
 
-property :name,                        String, required: true, name_property: true
 property :value,                       [String, Array]
 property :type,                        String, required: true
 property :ttl,                         Integer, default: 3600

--- a/resources/route53_zone.rb
+++ b/resources/route53_zone.rb
@@ -1,4 +1,3 @@
-property :name, String, required: true, name_property: true
 property :description, String
 property :private, [true, false], default: false
 property :vpc_id, String

--- a/resources/s3_bucket.rb
+++ b/resources/s3_bucket.rb
@@ -1,4 +1,3 @@
-property :name, String, name_property: true
 property :region, String, default: lazy { fallback_region }
 property :delete_all_objects, [true, false], default: false
 property :versioning, [true, false], default: false, desired_state: false

--- a/resources/secondary_ip.rb
+++ b/resources/secondary_ip.rb
@@ -1,4 +1,4 @@
-property :ip,                    String
+property :ip,                    String, required: true
 property :interface,             String, default: lazy { node['network']['default_interface'] }
 property :timeout,               [Integer, nil], default: 3 * 60 # 3 mins, nil or 0 for no timeout
 

--- a/resources/secondary_ip.rb
+++ b/resources/secondary_ip.rb
@@ -108,7 +108,12 @@ action_class do
 
   def interface_private_ips(interface)
     mac = interface_mac_address(interface)
-    ips = node['ec2']['network_interfaces_macs']['local_ipv4s'][mac]
+
+    begin
+      ips = node['ec2']['network_interfaces_macs']['local_ipv4s'][mac]
+    rescue NoMethodError # there's no local IPs
+      return []
+    end
     ips.split!("\n") if ips.is_a? String # ohai 14 will return an array
     Chef::Log.debug("#{interface} assigned local ipv4s addresses is/are #{ips.join(',')}")
     ips

--- a/tasks/maintainers.rb
+++ b/tasks/maintainers.rb
@@ -39,7 +39,6 @@ begin
       end
     end
   end
-
 rescue LoadError
   STDERR.puts "\n*** TomlRb not available. Skipping the Maintainers Rake task\n\n"
 end

--- a/test/fixtures/cookbooks/aws_test/recipes/secondary_ip.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/secondary_ip.rb
@@ -1,0 +1,12 @@
+aws_secondary_ip 'add secondary IP' do
+  ip '172.31.37.18'
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+end
+
+aws_secondary_ip 'remove secondary IP' do
+  ip '172.31.37.18'
+  action :unassign
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+end


### PR DESCRIPTION
Don't save state on the node
Move all helpers internally
Name the helpers better
Don't make calls out the metadata endpoint since we have this data in Ohai already
Use a lazily evaluated default interface value instead of logic that does the same thing

Signed-off-by: Tim Smith <tsmith@chef.io>