### PR TITLE
Move instance tag logic into AwsCookbook::Ec2 library

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -92,5 +92,13 @@ module AwsCookbook
       Chef::Log.debug("Initializing interface with client interface options: #{aws_interface_opts}")
       aws_interface.new(aws_interface_opts)
     end
+
+    def instance_tags(resource_id = instance_id)
+      aws_tags = {}
+      ec2.describe_tags(filters: [{ name: 'resource-id', values: [resource_id] }])[:tags].map do |tag|
+        aws_tags[tag[:key]] = tag[:value]
+      end
+      aws_tags
+    end
   end
 end

--- a/resources/resource_tag.rb
+++ b/resources/resource_tag.rb
@@ -74,12 +74,6 @@ action_class do
   include AwsCookbook::Ec2
 
   def current_tags
-    @current_tags ||= begin
-      aws_tags = {}
-      ec2.describe_tags(filters: [{ name: 'resource-id', values: [new_resource.resource_id] }])[:tags].map do |tag|
-        aws_tags[tag[:key]] = tag[:value]
-      end
-      aws_tags
-    end
+    @current_tags ||= instance_tags(new_resource.resource_id)
   end
 end


### PR DESCRIPTION
Signed-off-by: Ed Flanagan <ed@index.com>

### Description

Refresh of https://github.com/chef-cookbooks/aws/pull/258

Just moves the `current_tags` logic into `AwsCookbook::Ec2` so it's available
outside the resource.

### Issues Resolved

* https://github.com/chef-cookbooks/aws/issues/95

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
