### PR TITLE
add aws_instance_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This cookbook provides resources for configuring and managing nodes running in A
 - CloudWatch Instance Monitoring (`instance_monitoring`)
 - DynamoDB (`dynamodb_table`)
 - EBS Volumes (`ebs_volume`)
+- EC2 Instance Role (`instance_role`)
 - EC2 Instance Termination Protection (`instance_term_protection`)
 - Elastic IPs (`elastic_ip`)
 - Elastic Load Balancer (`elastic_lb`)
@@ -670,6 +671,40 @@ Allows detailed CloudWatch monitoring to be enabled for the current instance.
 
 ```ruby
 aws_instance_monitoring "enable detailed monitoring"
+```
+
+### aws_instance_role
+
+Used to associate an IAM role (by way of an IAM instance profile) with an instance. Replaces the instance's current role association if one already exists.
+
+#### Actions:
+
+- `associate` - Associate role with the instance (Default).
+
+#### Properties:
+
+- `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
+- `region` - The AWS region containing the instance. Default: The current region of the node when running in AWS or us-east-1 if the node is not in AWS.
+- `instance_id` - The id of the instance to modify. Default: The current instance.
+- `profile_arn` - The IAM instance profile to associate with the instance
+
+#### Requirements
+
+IAM permisions:
+ * `ec2:DescribeIamInstanceProfileAssociations`
+ * `ec2:AssociateIamInstanceProfile`
+   * Only needed if the instance is not already associated with an IAM role
+ * `ec2:ReplaceIamInstanceProfileAssociation`
+   * Only needed if the instance is already associated with an IAM role
+ * `iam:PassRole`
+   * This can be restricted to the resource of the IAM role being associated
+
+#### Examples:
+
+```ruby
+aws_instance_role "change to example role" do
+  profile_arn 'arn:aws:iam::123456789012:instance-profile/ExampleInstanceProfile'
+end
 ```
 
 ### aws_instance_term_protection

--- a/resources/instance_role.rb
+++ b/resources/instance_role.rb
@@ -1,0 +1,58 @@
+property :aws_access_key, String
+property :aws_secret_access_key, String
+property :aws_session_token, String
+property :aws_assume_role_arn, String
+property :aws_role_session_name, String
+property :region, String, default: lazy { fallback_region }
+property :instance_id, String, default: lazy { node['ec2']['instance_id'] }
+property :profile_arn, String
+
+include AwsCookbook::Ec2
+
+action :associate do
+  association = current_association
+  if association.nil?
+    converge_by('associate iam instance profile') do
+      ec2.associate_iam_instance_profile(
+        iam_instance_profile: {
+          arn: new_resource.profile_arn,
+        },
+        instance_id: new_resource.instance_id
+      )
+    end
+  elsif association.iam_instance_profile.arn != new_profile_arn
+    converge_by('replace iam instance profile association') do
+      ec2.replace_iam_instance_profile_association(
+        iam_instance_profile: {
+          arn: new_resource.profile_arn,
+        },
+        association_id: current_association.association_id
+      )
+    end
+  end
+end
+
+action_class do
+  include AwsCookbook::Ec2
+
+  def current_association
+    current_associations =
+      ec2.describe_iam_instance_profile_associations(
+        filters: [
+          {
+            name: 'instance-id',
+            values: [new_resource.instance_id],
+          },
+        ]
+      ).iam_instance_profile_associations
+    if current_associations.empty?
+      nil
+    else
+      current_associations[0]
+    end
+  end
+
+  def new_profile_arn
+    new_resource.profile_arn
+  end
+end


### PR DESCRIPTION
### Description

Allows a role to be associated with an instance. Replaces the instance's current role association if one already exists.

Should be useful in Chef recipes to allow for a less-privileged role to be assumed after initial bootstrapping.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
