### PR TITLE
Add named_iam_capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Manage CloudFormation stacks.
 - `disable_rollback`: Set this to `true` if you want stack rollback to be disabled if creation of the stack fails. Default: `false`
 - `stack_policy_body`: Optionally define a stack policy to apply to the stack, mainly used in protecting stack resources after they are created. For more information, see [Prevent Updates to Stack Resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html) in the CloudFormation user guide.
 - `iam_capability`: Set to `true` to allow the CloudFormation template to create IAM resources. This is the equivalent of setting `CAPABILITY_IAM` When using the SDK or CLI. Default: `false`
+- `named_iam_capability`: Set to `true` to allow the CloudFormation template to create IAM resources with custom names. This is the equivalent of setting `CAPABILITY_NAMED_IAM` When using the SDK or CLI. Default: `false`
 
 #### Examples:
 

--- a/resources/cloudformation_stack.rb
+++ b/resources/cloudformation_stack.rb
@@ -4,6 +4,7 @@ property :template_source, String, required: true
 property :parameters, Array, default: []
 property :disable_rollback, [true, false], default: false
 property :iam_capability, [true, false], default: false
+property :named_iam_capability, [true, false], default: false
 property :stack_policy_body, String
 property :region, String, default: lazy { fallback_region }
 
@@ -74,11 +75,13 @@ action_class do
       template_body: ::IO.read(@template_path),
       parameters: new_resource.parameters,
       disable_rollback: new_resource.disable_rollback,
+      capabilities: [],
     }
     unless new_resource.stack_policy_body.nil?
       options[:stack_policy_body] = new_resource.stack_policy_body
     end
-    options[:capabilities] = ['CAPABILITY_IAM'] if new_resource.iam_capability
+    options[:capabilities] << 'CAPABILITY_IAM' if new_resource.iam_capability
+    options[:capabilities] << 'CAPABILITY_NAMED_IAM' if new_resource.named_iam_capability
     options
   end
 


### PR DESCRIPTION
### Description

Resolves issue that if folks use custom names for their IAM resources can use the cloudformation stack resource.

* http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html

### Issues Resolved

Issue #315 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
