### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,7 @@ This feature is available only to instances within VPCs. It allows you to assign
 #### Properties:
 
 - `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
-- `ip` - the private IP address. If none is given on assignment, will assign a random IP in the subnet.
+- `ip` - the private IP address. - required.
 - `interface` - the network interface to assign the IP to. If none is given, uses the default interface.
 - `timeout` - connection timeout for EC2 API.
 


### PR DESCRIPTION
### Description

As of version 7.1.0 of the aws cookbook, the `ip` property is required on the secondary_ip resource in order to run.

### Issues Resolved

#314 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
