### PR TITLE
Add option to tag the new volumes and snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ The resource only handles manipulating the EBS volume, additional resources need
 - `encrypted` - specify if the EBS should be encrypted
 - `kms_key_id` - the full ARN of the AWS Key Management Service (AWS KMS) master key to use when creating the encrypted volume (defaults to master key if not specified)
 - `delete_on_termination` - Boolean value to control whether or not the volume should be deleted when the instance it's attached to is terminated (defaults to nil). Only applies to `:attach` action.
+- `tags` - Hash value to tag the new volumes or snapshots. Only applies to `:create` and `:snapshot` actions.
 
 #### Examples:
 

--- a/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
@@ -17,6 +17,16 @@ aws_ebs_volume 'standard_ebs_vol' do
   action [:create, :attach]
 end
 
+aws_ebs_volume 'standard_ebs_vol_with_tags' do
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  size 1
+  device '/dev/sdk'
+  tags('Environment' => 'test_kitchen')
+  delete_on_termination true
+  action [:create, :attach]
+end
+
 aws_ebs_volume 'ssd_ebs_volume' do
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']


### PR DESCRIPTION
### Description

Add an option to tag the new ebs volumes and snapshots created by the `aws_ebs_volume` library

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
