### PR TITLE
Rescue Aws::EC2::Errors::InvalidSnapshotInUse

### DIFF
--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -133,8 +133,8 @@ action :prune do
         Chef::Log.info "Deleting old snapshot #{die[:snapshot_id]}"
         begin
           ec2.delete_snapshot(snapshot_id: die[:snapshot_id])
-        rescue Aws::EC2::Errors::InvalidSnapshotInUse # rubocop: disable Lint/HandleExceptions
-          # Snapshot is being used by an AMI and therefore cannot be deleted.
+        rescue Aws::EC2::Errors::InvalidSnapshotInUse
+          Chef::Log.debug "Snapshot with ID #{die[:snapshot_id]} cannot be deleted because it is currently in use."
         end
       end
     end

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -133,7 +133,7 @@ action :prune do
         Chef::Log.info "Deleting old snapshot #{die[:snapshot_id]}"
         begin
           ec2.delete_snapshot(snapshot_id: die[:snapshot_id])
-        rescue Aws::EC2::Errors::InvalidSnapshotInUse
+        rescue Aws::EC2::Errors::InvalidSnapshotInUse # rubocop: disable Lint/HandleExceptions
           # Snapshot is being used by an AMI and therefore cannot be deleted.
         end
       end

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -131,7 +131,11 @@ action :prune do
     old_snapshots[new_resource.snapshots_to_keep, old_snapshots.length].each do |die|
       converge_by("delete snapshot with id: #{die[:snapshot_id]}") do
         Chef::Log.info "Deleting old snapshot #{die[:snapshot_id]}"
-        ec2.delete_snapshot(snapshot_id: die[:snapshot_id])
+        begin
+          ec2.delete_snapshot(snapshot_id: die[:snapshot_id])
+        rescue Aws::EC2::Errors::InvalidSnapshotInUse
+          # Snapshot is being used by an AMI and therefore cannot be deleted.
+        end
       end
     end
   end


### PR DESCRIPTION
### Description
When chef finds old snapshots, it tries to delete them. When the snapshot is being referenced in a AMI (Amazon Machine Image), it throws an Aws::EC2::Errors::InvalidSnapshotInUse and prevents chef from continuing running.

### Issues Resolved
No issues have been opened for this.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
