### PR TITLE
add `requester_pays` option to `s3_file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,15 @@ aws_s3_file '/tmp/foo' do
 end
 ```
 
+```ruby
+aws_s3_file '/tmp/bar' do
+  bucket 'i_haz_another_s3_buckit'
+  remote_path 'path/in/s3/buckit/to/foo'
+  region 'us-east-1'
+  requester_pays true
+end
+```
+
 ### aws_s3_bucket
 
 `s3_bucket` can be used to create or delete S3 buckets. Note that buckets can only be deleted if they are empty unless you specify `delete_all_objects` true, which will delete EVERYTHING in your bucket first.

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -2,6 +2,7 @@ property :path, String, name_property: true
 property :remote_path, String
 property :region, String, default: lazy { fallback_region }
 property :bucket, String
+property :requester_pays, [true, false], default: false
 property :owner, regex: Chef::Config[:user_valid_regex]
 property :group, regex: Chef::Config[:group_valid_regex]
 property :mode, [String, nil]
@@ -96,7 +97,9 @@ action_class do
       end
     end
 
-    s3url = s3_obj.presigned_url(:get, expires_in: 300).gsub(%r{https://([\w\.\-]*)\.\{1\}s3.amazonaws.com:443}, 'https://s3.amazonaws.com:443/\1') # Fix for ssl cert issue
+    s3_url_params = { expires_in: 300 }
+    s3_url_params[:request_payer] = 'requester' if new_resource.requester_pays
+    s3url = s3_obj.presigned_url(:get, s3_url_params).gsub(%r{https://([\w\.\-]*)\.\{1\}s3.amazonaws.com:443}, 'https://s3.amazonaws.com:443/\1') # Fix for ssl cert issue
     Chef::Log.debug("Using S3 URL #{s3url}")
 
     remote_file new_resource.name do


### PR DESCRIPTION
### Description

Allows download of objects in buckets marked as `Requester Pays`

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
