### PR TITLE
Pass `http_proxy` to the AWS client options

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -64,7 +64,8 @@ module AwsCookbook
 
     # setup AWS instance using passed creds, iam profile, or assumed role
     def create_aws_interface(aws_interface, **opts)
-      aws_interface_opts = { region: opts[:region] }
+      aws_interface_opts = { region: opts[:region],
+                             http_proxy: ENV['http_proxy'] }
 
       if opts[:mock] # return a mocked interface
         aws_interface_opts[:stub_responses] = true
@@ -83,6 +84,7 @@ module AwsCookbook
         if !new_resource.aws_assume_role_arn.to_s.empty? && !new_resource.aws_role_session_name.to_s.empty?
           Chef::Log.debug("Assuming role #{new_resource.aws_assume_role_arn}")
           sts_client = ::Aws::STS::Client.new(region: opts[:region],
+                                              http_proxy: ENV['http_proxy'],
                                               access_key_id: new_resource.aws_access_key,
                                               secret_access_key: new_resource.aws_secret_access_key)
           creds = ::Aws::AssumeRoleCredentials.new(client: sts_client, role_arn: new_resource.aws_assume_role_arn, role_session_name: new_resource.aws_role_session_name)


### PR DESCRIPTION
### Description

Adds passing `http_proxy: ENV['http_proxy']` to `create_aws_interface` so it gets passed to Seahorse::Client and the request can traverse a proxy.

Downloading a file works fine without it, since it's just using the AWS SDK to generate a presigned URL which is then passed to `remote_file` which simply utilizes `net::http` which will utilize the `http_proxy` environment variable if it not explicitly set to `nil`.

https://github.com/chef/chef/blob/master/lib/chef/provider/remote_file/http.rb#L65

The problem is that on a second run, it attempts to retrieve the S3 key etag to check the against the local file md5 hash at

https://github.com/chef-cookbooks/aws/blob/master/resources/s3_file.rb#L77

It is within this call that it utilizes the AWS SDK to retrieve the etag, that eventually makes it to `AWS::Seahorse::Client::NetHttp::ConnectionPool` where `http_proxy` is explicitly set to `nil` so when it utilizes `net::http` to execute the request, it does not fall back to the proxy environment variables.

https://github.com/aws/aws-sdk-ruby/blob/v2.11.48/aws-sdk-core/lib/seahorse/client/net_http/connection_pool.rb#L19

### Issues Resolved

Fixes #346

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
