### PR TITLE
fix check for attached instances crash

### DIFF
--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -311,7 +311,7 @@ action_class do
   # Deletes the volume and blocks until done (or times out)
   def delete_volume(volume_id, timeout)
     vol = volume_by_id(volume_id)
-    raise "Cannot delete volume #{volume_id} as it is currently attached to #{volume_by_id(volume_id)[:attachments].size} node(s)" unless vol[:attachments].empty?
+    raise "Cannot delete volume #{volume_id} as it is currently attached to #{vol[:attachments].size} node(s)" unless vol[:attachments].empty?
 
     Chef::Log.debug("Deleting #{volume_id}")
     ec2.delete_volume(volume_id: volume_id)

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -310,6 +310,7 @@ action_class do
 
   # Deletes the volume and blocks until done (or times out)
   def delete_volume(volume_id, timeout)
+    vol = volume_by_id(volume_id)
     raise "Cannot delete volume #{volume_id} as it is currently attached to #{volume_by_id(volume_id)[:attachments].size} node(s)" unless vol[:attachments].empty?
 
     Chef::Log.debug("Deleting #{volume_id}")


### PR DESCRIPTION
### Description

The check for instances attached to this volume cannot run because it depends on a vol hash. That hash is not initialized at this point. In previous versions of the cookbook, it appears that we fetched the full volume hash prior to this check. 

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
