### PR TITLE
Cleanup Parameter Store

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: ec2
-  instance_type: t1.micro
+  instance_type: t3.micro
 
 transport:
   ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
@@ -113,3 +113,8 @@ suites:
   - name: ssm_parameter_store
     run_list:
     - recipe[aws_test::ssm_parameter_store]
+    attributes:
+      aws_test:
+        key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+        access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+        session_token: <%= ENV['AWS_SESSION_TOKEN'] %>

--- a/README.md
+++ b/README.md
@@ -1023,8 +1023,8 @@ The `ssm_parameter_store` resource provider allows one to get, create and delete
 #### Actions:
 
 - `get` - Retrieve a key/value from the AWS Systems Manager Parameter Store.
-- `get_parameters` - Retrieve multiple key/values by name from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the key name.
-- `get_parameters_by_path` - Retrieve multiple key/values by path from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the keys leaf name.  If recursive is set to true the code will retrieve all parameters in the path hierarchy.
+- `get_parameters` - Retrieve multiple key/values by name from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the corresponding path value.
+- `get_parameters_by_path` - Retrieve multiple key/values by path from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the key's name.  If recursive is set to true, it will retrieve all parameters in the path hierarchy, constructing a representative hash structure with nested keys/values.
 - `create` - Create a key/value in the AWS Systems Manager Parameter Store.
 - `delete` - Remove the key/value from the AWS Systems Manager Parameter Store.
 

--- a/README.md
+++ b/README.md
@@ -1024,16 +1024,14 @@ The `ssm_parameter_store` resource provider allows one to get, create and delete
 
 - `get` - Retrieve a key/value from the AWS Systems Manager Parameter Store.
 - `get_parameters` - Retrieve multiple key/values by name from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the key name.
-- `get_parameters_by_path` - Retrieve multiple key/values by path from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the key name.  If recursive is set to true the code will retrieve all parameters in the path hierarchy.
+- `get_parameters_by_path` - Retrieve multiple key/values by path from the AWS Systems Manager Parameter Store.  Values are stored in a hash indexed by the keys leaf name.  If recursive is set to true the code will retrieve all parameters in the path hierarchy.
 - `create` - Create a key/value in the AWS Systems Manager Parameter Store.
 - `delete` - Remove the key/value from the AWS Systems Manager Parameter Store.
 
 #### Properties:
 
 - `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
-- `name` - Identifies the parameters (get, create, delete, required)
-- `names` - Used to specify multiple parameters (get_parameters, required)
-- `path` - Specify the parameter hierarchy where parameters are located (get_parameters_by_path, required)
+- `path` - Specify the target parameter (String) or parameters (Array - `:get_parameters`). (required)
 - `recursive` - If set to `true` the code will retrieve all parameters in the hierarchy (get_parameters_by_path, optional defaults to false)
 - `description` - Type a description to help identify parameters and their intended use. (create, optional)
 - `value` - Item stored in AWS Systems Manager Parameter Store (create, required)
@@ -1047,7 +1045,7 @@ The `ssm_parameter_store` resource provider allows one to get, create and delete
 ##### Create String Parameter
 ```ruby
 aws_ssm_parameter_store 'create testkitchen record' do
-  name 'testkitchen'
+  path 'testkitchen'
   description 'testkitchen'
   value 'testkitchen'
   type 'String'
@@ -1056,10 +1054,11 @@ aws_ssm_parameter_store 'create testkitchen record' do
   aws_secret_access_key node['aws_test']['access_key']
 end
 ```
+
 ##### Create Encrypted String Parameter with Custom KMS Key
 ```ruby
 aws_ssm_parameter_store "create encrypted test kitchen record" do
-  name '/testkitchen/EncryptedStringCustomKey'
+  path '/testkitchen/EncryptedStringCustomKey'
   description 'Test Kitchen Encrypted Parameter - Custom'
   value 'Encrypted Test Kitchen Custom'
   type 'SecureString'
@@ -1072,7 +1071,7 @@ aws_ssm_parameter_store "create encrypted test kitchen record" do
 ##### Delete Parameter
 ```ruby
 aws_ssm_parameter_store 'delete testkitchen record' do
-  name 'testkitchen'
+  path 'testkitchen'
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
   action :delete
@@ -1081,7 +1080,7 @@ end
 ##### Get Parameters and Populate Template
 ```ruby
 aws_ssm_parameter_store 'get clear_value' do
-  name '/testkitchen/ClearTextString'
+  path '/testkitchen/ClearTextString'
   return_key 'clear_value'
   action :get
   aws_access_key node['aws_test']['key_id']
@@ -1089,7 +1088,7 @@ aws_ssm_parameter_store 'get clear_value' do
 end
 
 aws_ssm_parameter_store 'get decrypted_value' do
-  name '/testkitchen/EncryptedStringDefaultKey'
+  path '/testkitchen/EncryptedStringDefaultKey'
   return_key 'decrypted_value'
   with_decryption true
   action :get
@@ -1098,7 +1097,7 @@ aws_ssm_parameter_store 'get decrypted_value' do
 end
 
 aws_ssm_parameter_store 'get decrypted_custom_value' do
-  name '/testkitchen/EncryptedStringCustomKey'
+  path '/testkitchen/EncryptedStringCustomKey'
   return_key 'decrypted_custom_value'
   with_decryption true
   action :get
@@ -1107,7 +1106,7 @@ aws_ssm_parameter_store 'get decrypted_custom_value' do
 end
 
 aws_ssm_parameter_store 'getParameters' do
-  names ['/testkitchen/ClearTextString', '/testkitchen']
+  path ['/testkitchen/ClearTextString', '/testkitchen']
   return_keys 'parameter_values'
   action :get_parameters
   aws_access_key node['aws_test']['key_id']
@@ -1123,40 +1122,12 @@ aws_ssm_parameter_store 'getParametersbypath' do
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
 end
+```
 
-template '/tmp/file_with_data.txt' do
-  source 'file_with_data.txt.erb'
-  owner 'ec2-user'
-  group 'ec2-user'
-  mode '0755'
-  sensitive true
-  variables lazy {
-    {
-       clear_value: node.run_state['clear_value'],
-       decrypted_custom_value: node.run_state['decrypted_custom_value'],
-       decrypted_value: node.run_state['decrypted_value'],
-       path1_value: node.run_state['path_values']['/pathtest/path1'],
-       path2_value: node.run_state['path_values']['/pathtest/path2'],
-       parm1_value: node.run_state['parameter_values']['/testkitchen/ClearTextString'],
-       parm2_value: node.run_state['parameter_values']['/testkitchen'],
-    }
-  }
-end
-```
-###### Template (file_with_data.txt.erb)
-```ruby
-ClearValue="<%= @clear_value %>"
-DecryptedCustomValue="<%= @decrypted_custom_value %>"
-DecryptedValue="<%= @decrypted_value %>"
-Path1_value = "<%= @path1_value %>"
-Path2_value = "<%= @path2_value %>"
-Parm1_value = "<%= @parm1_value %>"
-Parm2_value = "<%= @parm2_value %>"
-```
 ##### Get bucket name and retrieve file
 ```ruby
 aws_ssm_parameter_store 'get bucketname' do
-  name 'bucketname'
+  path 'bucketname'
   return_key 'bucketname'
   action :get
   aws_access_key node['aws_test']['key_id']

--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -126,18 +126,15 @@ action_class do
   end
 
   def write_parameter
-    # If the paremeter doesn't exist or one of the values has changed and overwrite
-    # is set to true then we'll write the parameter.
-    return true if new_resource.overwrite
-
     request = {
       name: new_resource.path,
       with_decryption: (new_resource.type == 'SecureString'),
     }
-
+    # => Poll the Parameter's existence
     r = ssm_client.get_parameter(request)
-    return false if r.parameter.name == new_resource.path && r.parameter.value == new_resource.value
-    true
+    return false if r.parameter.value == new_resource.value
+    return true if new_resource.overwrite
+    false
   rescue Aws::SSM::Errors::ParameterNotFound
     true
   end

--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -1,20 +1,31 @@
-property :description, String
-property :value, String, required: true
-property :type, String, required: true
-property :key_id, String
-property :overwrite, [true, false], default: true
-property :with_decryption, [true, false], default: false
-property :allowed_pattern, String
-property :return_key, String
-property :names, [String, Array], required: true
-property :return_keys, [String, Hash]
-property :path, String, required: true
-property :recursive, [true, false], default: false
-property :parameter_filters, String
-property :next_token, String
-property :max_results, Integer
+#
+# Cookbook:: aws
+# Resource:: ssm_parameter_store
+#
 
-# authentication
+resource_name :ssm_parameter_store
+provides :aws_ssm_parameter_store
+
+# => Define the Resource Properties
+property :path, [String, Array], name_property: true
+
+# => Retrieval Properties
+property :recursive,       [FalseClass, TrueClass], default: false
+property :with_decryption, [false, true], default: false
+# => run_state key to put the Retrieved Value(s)
+property :return_key,        String
+property :parameter_filters, Array, required: false
+property :max_results,       Integer
+
+# => Create Properties
+property :value,           String
+property :description,     String
+property :type,            %w(String StringList SecureString)
+property :key_id,          String
+property :overwrite,       [false, true], default: true
+property :allowed_pattern, String
+
+# => AWS Config
 property :aws_access_key, String
 property :aws_secret_access_key, String
 property :aws_session_token, String
@@ -23,154 +34,105 @@ property :aws_role_session_name, String
 property :region, String, default: lazy { fallback_region }
 
 include AwsCookbook::Ec2 # needed for aws_region helper
+include Chef::Mixin::DeepMerge
 
 # allow use of the property names from the parameter store cookbook
 alias_method :aws_access_key_id, :aws_access_key
 alias_method :aws_region, :region
 
+# => Retrieve Single Parameter
 action :get do
   request = {
-    name: name,
-    with_decryption: with_decryption,
+    name: new_resource.path,
+    with_decryption: new_resource.with_decryption,
   }
+  Chef::Log.debug "Get parameter: #{request[:name]}"
   resp = ssm_client.get_parameter(request)
   node.run_state[new_resource.return_key] = resp.parameter.value
-  Chef::Log.debug "Get parameter #{name}"
 end
 
+# => Retrieve Multiple Parameters
 action :get_parameters do
   request = {
-    names: names,
-    with_decryption: with_decryption,
+    names: Array(new_resource.path),
+    with_decryption: new_resource.with_decryption,
   }
+  Chef::Log.debug "Get parameters: #{request[:names]}"
   resp = ssm_client.get_parameters(request)
   secret_info = {}
   resp.parameters.each do |secret|
     secret_info[secret.name] = secret.value
   end
-  Chef::Log.debug "Get parameters #{names}"
-  node.run_state[new_resource.return_keys] = secret_info
+  node.run_state[new_resource.return_key] = secret_info
 end
 
 action :get_parameters_by_path do
-  secrets = []
+  # => Build the Request
   request = {
-    path: path,
-    recursive: recursive,
-    parameter_filters: parameter_filters,
-    with_decryption: with_decryption,
-    max_results: max_results,
-    next_token: next_token,
+    path: new_resource.path,
+    recursive: new_resource.recursive,
+    parameter_filters: new_resource.parameter_filters,
+    with_decryption: new_resource.with_decryption,
+    max_results: new_resource.max_results,
   }
-  ssm_client.get_parameters_by_path(request).each do |resp|
-    secrets.push(*resp.parameters)
+  Chef::Log.debug "Get parameters by path #{request[:path]}"
+  resp = ssm_client.get_parameters_by_path(request)
+  resp.parameters.each do |parm|
+    # => Convert the Param to a Hash
+    hsh = param_to_hash(parm.name, parm.value)
+    # => Merge the resulting Hash into the Destination
+    deep_merge!(hsh, node.run_state[new_resource.return_key] ||= {})
   end
-  secret_info = {}
-  secrets.each do |secret|
-    secret_info[secret.name] = secret.value
-  end
-  Chef::Log.debug "Get parameters by path #{path}"
-  node.run_state[new_resource.return_keys] = secret_info
 end
 
 action :create do
   if write_parameter
     request = {
-      name: name,
-      description: description,
-      value: value,
-      type: type,
-      key_id: key_id,
-      overwrite: overwrite,
-      allowed_pattern: allowed_pattern,
+      name: new_resource.path,
+      description: new_resource.description,
+      value: new_resource.value,
+      type: new_resource.type,
+      key_id: new_resource.key_id,
+      overwrite: new_resource.overwrite,
+      allowed_pattern: new_resource.allowed_pattern,
     }
+    Chef::Log.debug "Put parameter #{new_resource.path}"
     ssm_client.put_parameter(request)
-    Chef::Log.debug "Put parameter #{name}"
   end
 end
 
 action :delete do
   request = {
-    name: name,
+    name: new_resource.path,
   }
+  Chef::Log.info "Deleting Parameter: #{new_resource.path}"
   ssm_client.delete_parameter(request)
-  Chef::Log.info "parameter deleted: #{name}"
 end
 
 action_class do
   include AwsCookbook::Ec2
 
-  def name
-    @name ||= new_resource.name
-  end
-
-  def value
-    @value ||= new_resource.value
-  end
-
-  def type
-    @type ||= new_resource.type
-  end
-
-  def description
-    @description ||= new_resource.description
-  end
-
-  def key_id
-    @key_id ||= new_resource.key_id
-  end
-
-  def overwrite
-    @overwrite ||= new_resource.overwrite
-  end
-
-  def with_decryption
-    @with_decryption ||= new_resource.with_decryption
-  end
-
-  def allowed_pattern
-    @allowed_pattern ||= new_resource.allowed_pattern
-  end
-
-  def names
-    @names ||= new_resource.names
-  end
-
-  def path
-    @path ||= new_resource.path
-  end
-
-  def recursive
-    @recursive ||= new_resource.recursive
-  end
-
-  def parameter_filters
-    @parameter_filters ||= new_resource.parameter_filters
-  end
-
-  def next_token
-    @next_token ||= new_resource.next_token
-  end
-
-  def max_results
-    @max_results ||= new_resource.max_results
+  def param_to_hash(path, value)
+    # => Recursively descend a ParameterStore Path and build a Hash
+    #  INPUT: '/Ensure/This/Path' = 'Exists'
+    # OUTPUT: ['Ensure']['This']['Path'] => 'Exists'
+    path.split('/').reject(&:empty?).reverse.inject(value) { |acc, elem| { elem => acc } }
   end
 
   def write_parameter
     # If the paremeter doesn't exist or one of the values has changed and overwrite
     # is set to true then we'll write the parameter.
+    return true if new_resource.overwrite
 
     request = {
-      name: name,
-      with_decryption: (type == 'SecureString'),
+      name: new_resource.path,
+      with_decryption: (new_resource.type == 'SecureString'),
     }
-    response = ssm_client.get_parameter(request)
-    return false if response.parameter.name == name && response.parameter.value == value
-    return true if new_resource.overwrite
-    false
-  rescue Aws::SSM::Errors::ParameterNotFound => msg
-    # Paremeter doesn't exist
-    Chef::Log.info "get_parameter exception: #{msg}"
+
+    r = ssm_client.get_parameter(request)
+    return false if r.parameter.name == new_resource.path && r.parameter.value == new_resource.value
+    true
+  rescue Aws::SSM::Errors::ParameterNotFound
     true
   end
 

--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -83,7 +83,6 @@ action :get_parameters_by_path do
   end
   parms.each do |parm|
     # => Strip Leading Path
-    # pname = parm.name.sub(request[:path], '')
     pname = parm.name.sub(::Pathname.new(request[:path]).cleanpath.to_s, '')
     # => Convert the Param to a Hash
     hsh = param_to_hash(pname, parm.value)

--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -78,8 +78,10 @@ action :get_parameters_by_path do
   Chef::Log.debug "Get parameters by path #{request[:path]}"
   resp = ssm_client.get_parameters_by_path(request)
   resp.parameters.each do |parm|
+    # => Strip Leading Path
+    pname = parm.name.sub(::File.dirname(request[:path]), '')
     # => Convert the Param to a Hash
-    hsh = param_to_hash(parm.name, parm.value)
+    hsh = param_to_hash(pname, parm.value)
     # => Merge the resulting Hash into the Destination
     deep_merge!(hsh, node.run_state[new_resource.return_key] ||= {})
   end

--- a/test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/ssm_parameter_store.rb
@@ -71,20 +71,6 @@ aws_ssm_parameter_store 'Get Parameters by Path' do
   aws_secret_access_key node['aws_test']['access_key']
 end
 
-file '/tmp/test_params' do
-  content(
-    lazy { node.run_state['path_values'].inspect }
-  )
-  action :create
-end
-
-ruby_block 'test_params' do
-  block do
-    Chef::Log.warn Chef::JSONCompat.to_json_pretty(node.run_state['path_values'])
-  end
-  action :run
-end
-
 aws_ssm_parameter_store 'get clear_value' do
   path '/testkitchen/ClearTextString'
   return_key 'clear_value'
@@ -102,15 +88,6 @@ aws_ssm_parameter_store 'get decrypted_value' do
   aws_secret_access_key node['aws_test']['access_key']
 end
 
-# aws_ssm_parameter_store 'get decrypted_custom_value' do
-# name '/testkitchen/EncryptedStringCustomKey'
-# return_key 'decrypted_custom_value'
-# with_decryption true
-# action :get
-# aws_access_key node['aws_test']['key_id']
-# aws_secret_access_key node['aws_test']['access_key']
-# end
-
 file '/tmp/ssm_parameters.json' do
   content lazy {
     Chef::JSONCompat.to_json_pretty(
@@ -119,8 +96,8 @@ file '/tmp/ssm_parameters.json' do
       decrypted_value: node.run_state['decrypted_value'],
       path_values: node.run_state['path_values'],
       parameter_values: node.run_state['parameter_values'],
-      path1_value: node.run_state['path_values']['pathtest']['path1'],
-      path2_value: node.run_state['path_values']['pathtest']['path2'],
+      path1_value: node.run_state['path_values']['path1'],
+      path2_value: node.run_state['path_values']['path2'],
       parm1_value: node.run_state['parameter_values']['/testkitchen/ClearTextString'],
       parm2_value: node.run_state['parameter_values']['/testkitchen']
     )

--- a/test/fixtures/cookbooks/aws_test/templates/file_with_data.txt.erb
+++ b/test/fixtures/cookbooks/aws_test/templates/file_with_data.txt.erb
@@ -1,7 +1,0 @@
-ClearValue="<%= @clear_value %>"
-# DecryptedCustomValue="<%= @decrypted_custom_value %>"
-DecryptedValue="<%= @decrypted_value %>"
-Path1_value = "<%= @path1_value %>"
-Path2_value = "<%= @path2_value %>"
-Parm1_value = "<%= @parm1_value %>"
-Parm2_value = "<%= @parm2_value %>"

--- a/test/integration/ssm_parameter_store/default_spec.rb
+++ b/test/integration/ssm_parameter_store/default_spec.rb
@@ -12,6 +12,6 @@ describe json('/tmp/ssm_parameters.json') do
   its(%w(parameter_values /testkitchen/ClearTextString)) { should eq 'Clear Text Test Kitchen' }
 
   # => Get Parameters by Path - Hash Return (:get_parameters_by_path)
-  its(%w(path_values pathtest path1)) { should eq 'path1_value' }
-  its(%w(path_values pathtest path2)) { should eq 'path2_value' }
+  its(%w(path_values path1)) { should eq 'path1_value' }
+  its(%w(path_values path2)) { should eq 'path2_value' }
 end

--- a/test/integration/ssm_parameter_store/default_spec.rb
+++ b/test/integration/ssm_parameter_store/default_spec.rb
@@ -1,0 +1,17 @@
+describe json('/tmp/ssm_parameters.json') do
+  # => Get (:get)
+  its('clear_value') { should eq 'Clear Text Test Kitchen' }
+  its('decrypted_value') { should eq 'Encrypted Test Kitchen Default' }
+  its('path1_value') { should eq 'path1_value' }
+  its('path2_value') { should eq 'path2_value' }
+  its('parm1_value') { should eq 'Clear Text Test Kitchen' }
+  its('parm2_value') { should eq 'testkitchen' }
+
+  # => Get Parameters (:get_parameters)
+  its(%w(parameter_values /testkitchen)) { should eq 'testkitchen' }
+  its(%w(parameter_values /testkitchen/ClearTextString)) { should eq 'Clear Text Test Kitchen' }
+
+  # => Get Parameters by Path - Hash Return (:get_parameters_by_path)
+  its(%w(path_values pathtest path1)) { should eq 'path1_value' }
+  its(%w(path_values pathtest path2)) { should eq 'path2_value' }
+end


### PR DESCRIPTION
### Description

This fixes some namespacing issues and cleans up the `ssm_parameter_store` resource parameters a bit.

It also adds proper handling of pagination for path-based queries.  Additionally, the results from a path-based query are now coerced into a hash representative of the ParameterStore heirarchy.

Example:
```ruby
# ParameterStore
# /this/is/a/deeply/nested = 'hash'

aws_ssm_parameter_store 'Get Parameters by Path' do
  path '/this/is/a'
  recursive true
  return_key 'pstore'
  action :nothing
end.run_action(:get_parameters_by_path)

# Result
pp node.run_state['pstore']
{
  "deeply": {
    "nested": "hash"
  }
}
```

### Issues Resolved

#357 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
