### PR TITLE
add `alias_method` for `reutrn_key` and `return_keys`

### DIFF
--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -38,6 +38,7 @@ include Chef::Mixin::DeepMerge
 # allow use of the property names from the parameter store cookbook
 alias_method :aws_access_key_id, :aws_access_key
 alias_method :aws_region, :region
+alias_method :return_key, :return_keys
 
 # => Retrieve Single Parameter
 action :get do


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

Fixes an issue where a parameter interface was removed and no alias provided for backwards compatibility.

### Issues Resolved

fixes #370 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
