### PR TITLE
Use the right alias for return_keys and return_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ end
 
 aws_ssm_parameter_store 'getParameters' do
   path ['/testkitchen/ClearTextString', '/testkitchen']
-  return_keys 'parameter_values'
+  return_key 'parameter_values'
   action :get_parameters
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
@@ -1117,7 +1117,7 @@ aws_ssm_parameter_store 'getParametersbypath' do
   path '/pathtest/'
   recursive true
   with_decryption true
-  return_keys 'path_values'
+  return_key 'path_values'
   action :get_parameters_by_path
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
@@ -1154,7 +1154,7 @@ end
 
 #### Actions:
 
-- `attach_instance`: Attach an instance to an ASG.  If the instance is already attached it will generate an error.  
+- `attach_instance`: Attach an instance to an ASG.  If the instance is already attached it will generate an error.
 - `detach_instance`: Detach an instance from an ASG.  If the instance is not already attached and in service it will generate an error.
 - `enter_standby`: Put ths instance into standby mode.  Will generate an error if already in standby mode
 - `exit_standby`: Remove the instance from standby mode.  Will generate an error if not in standby mode

--- a/resources/ssm_parameter_store.rb
+++ b/resources/ssm_parameter_store.rb
@@ -38,7 +38,7 @@ include Chef::Mixin::DeepMerge
 # allow use of the property names from the parameter store cookbook
 alias_method :aws_access_key_id, :aws_access_key
 alias_method :aws_region, :region
-alias_method :return_key, :return_keys
+alias_method :return_keys, :return_key
 
 # => Retrieve Single Parameter
 action :get do


### PR DESCRIPTION
I tested this locally.

Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

[Describe what this change achieves]

### Issues Resolved

fixes #370 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
