### PR TITLE
Added a basic chefspec test

### DIFF
--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,3 +1,11 @@
 require 'spec_helper'
 
-# specs coming here!
+describe 'aws::default' do
+  # Nothing in this test is platform-specific, so use the latest Ubuntu for
+  # simulated data.
+  platform 'ubuntu'
+
+  context 'does not raise an error' do
+    it { expect { chef_run }.to_not raise_error }
+  end
+end


### PR DESCRIPTION
PR https://github.com/chef-cookbooks/aws/pull/371 passed the CI run
(i.e. https://travis-ci.org/chef-cookbooks/aws/jobs/469385237), but the
recipe fails during compilation.

Signed-off-by: Eduardo A. Bustamante López <dualbus@gmail.com>

### Description

This change provides a minimal safety net, future recipe compilation errors
should break the build.

Some form of unit / integration testing is actually required by the Chef community cookbooks contribution guidelines: https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD#pull-request-requirements

### Issues Resolved

This does not resolve any issues, but it should prevent issues like https://github.com/chef-cookbooks/aws/issues/370 from happening again.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
