### PR TITLE
account for timezone in setting s3 presigned url expiration

### DIFF
--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -127,7 +127,8 @@ action_class do
   end
 
   def s3_url
-    s3_url_params = { expires_in: 300 }
+    utc_offset = Time.new.utc_offset
+    s3_url_params = { expires_in: 300 + utc_offset.abs }
     s3_url_params[:request_payer] = 'requester' if new_resource.requester_pays
     s3url = s3_obj.presigned_url(:get, s3_url_params).gsub(%r{https://([\w\.\-]*)\.\{1\}s3.amazonaws.com:443}, 'https://s3.amazonaws.com:443/\1') # Fix for ssl cert issue
     Chef::Log.debug("Using S3 URL #{s3url}")


### PR DESCRIPTION

### Description

Attempts to fix bugs with being unable to get `s3_file` working on machines that do not report their time in UTC timezone.

### Issues Resolved

#380 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
