### PR TITLE
accept the chef license when chef is run on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
 # Ensure we make ChefDK's Ruby the default
 before_script:
   - eval "$(chef shell-init bash)"
+  - export CHEF_LICENSE="accept-silent"
 
 script:
   - chef --version


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

### Description

fixes the travis builds which are broken with the latest chef version


### Issues Resolved

```
120.77s$ chef exec delivery local all
+---------------------------------------------+
            Chef License Acceptance
Before you can continue, 3 product licenses
must be accepted. View the license at
https://www.chef.io/end-user-license-agreement/
Licenses that need accepting:
  * Chef Development Kit
  * Chef Infra Client
  * Chef InSpec
Do you accept the 3 product licenses (yes/no)?
> Prompt timed out. Use non-interactive flags or enter an answer within 60 seconds.
If you do not accept this license you will
not be able to use Chef products.
Do you accept the 3 product licenses (yes/no)?
> Prompt timed out. Use non-interactive flags or enter an answer within 60 seconds.
+---------------------------------------------+
Chef Development Kit cannot execute without accepting the license
The command "chef exec delivery local all" exited with 172.
```

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
