### PR TITLE
Ignore tags with prefix aws: instead of aws

### DIFF
--- a/resources/resource_tag.rb
+++ b/resources/resource_tag.rb
@@ -18,9 +18,9 @@ action :update do
   if updated_tags.eql?(current_tags)
     Chef::Log.debug("AWS: Tags for resource #{new_resource.resource_id} are unchanged")
   else
-    # tags that begin with "aws" are reserved
+    # tags that begin with "aws:" are reserved
     converge_by("Updating the following tags for resource #{new_resource.resource_id} (skipping AWS tags): " + updated_tags.inspect) do
-      updated_tags.delete_if { |key, _value| key.to_s =~ /^aws/ }
+      updated_tags.delete_if { |key, _value| key.to_s =~ /^aws:/ }
       ec2.create_tags(resources: [new_resource.resource_id], tags: updated_tags.collect { |k, v| { key: k, value: v } })
     end
   end


### PR DESCRIPTION
### Description

In the AWS [documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions), the `aws:` prefix is called out as being reserved for internal AWS use. However, in this resource we filter out all tags that start with `aws` instead of the more specific `aws:`.

This PR attempts to correct this by filtering out any tags that start with `aws:` instead of the more general `aws`.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
