### PR TITLE
Avoid resource overloading for aws_route53_record

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ end
 
 - `aws_secret_access_key`, `aws_access_key` and optionally `aws_session_token` - required, unless using IAM roles for authentication.
 - `name` Required. String. - name of the domain or subdomain.
+- `record_name` Optional. String. - name of the domain or subdomain overrides the `name`. Useful property to use when the resource was called with the same `name` and different values, like in [Split view DNS](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns) structure.   
 - `value` String Array - value appropriate to the `type`.. for type 'A' value would be an IP address in IPv4 format for example.
 - `type` Required. String [DNS record type](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html)
 - `ttl` Integer default: 3600 - time to live, the amount of time in seconds to cache information about the record

--- a/resources/route53_record.rb
+++ b/resources/route53_record.rb
@@ -6,6 +6,7 @@ property :value,                       [String, Array]
 property :type,                        String, required: true
 property :ttl,                         Integer, default: 3600
 property :weight,                      String
+property :record_name,                 String
 property :set_identifier,              String
 property :geo_location,                String
 property :geo_location_country,        String
@@ -76,6 +77,16 @@ action_class do
   # convert the passed name to the trailing period format
   def name
     @name ||= new_resource.name[-1] == '.' ? new_resource.name : "#{new_resource.name}."
+  end
+
+  def record_name
+    if new_resource.record_name
+      @record_name ||= new_resource.record_name[-1] == '.' ? new_resource.record_name : "#{new_resource.record_name}."
+    end
+  end
+
+  def fqdn
+    @fqdn = record_name || name
   end
 
   def value
@@ -157,7 +168,7 @@ action_class do
 
   def resource_record_set
     rr_set = {
-      name: name,
+      name: fqdn,
       type: type,
     }
     if alias_target
@@ -181,12 +192,12 @@ action_class do
     lrrs = route53_client
            .list_resource_record_sets(
              hosted_zone_id: zone_id ? "/hostedzone/#{zone_id}" : zone_id_from_name(zone_name),
-             start_record_name: name
+             start_record_name: fqdn
            )
 
     # Select current resource record set by name and geo location.
     current = lrrs[:resource_record_sets]
-              .select { |rr| rr[:name] == name && rr[:type] == type && rr[:geo_location].to_h == geo_location.to_h }.first
+              .select { |rr| rr[:name] == fqdn && rr[:type] == type && rr[:geo_location].to_h == geo_location.to_h }.first
 
     # return as hash, converting resource record
     # array of structs to array of hashes


### PR DESCRIPTION
### Description
`aws_route53_record` resource `name` is overused and throws an error when two same DNS records with different zone_id's are provisioned.
This PR supports the multiple DNS record provision with different zone_id's. It is often useful when you have a [split-view DNS](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns) or [Public and private hosted zones that have overlapping namespaces](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-public-private-overlapping).

This change is backward compatible.

### Issues Resolved
Issue#[407]( https://github.com/chef-cookbooks/aws/issues/403)

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>