### PR TITLE
feat(volume-type): add gp3 and io2 volume types to allowed types

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,9 @@ The resource only handles manipulating the EBS volume, additional resources need
 - `timeout` - connection timeout for EC2 API.
 - `snapshots_to_keep` - used with action `:prune` for number of snapshots to maintain.
 - `description` - used to set the description of an EBS snapshot
-- `volume_type` - "standard", "io1", or "gp2" ("standard" is magnetic, "io1" is provisioned SSD, "gp2" is general purpose SSD)
-- `piops` - number of Provisioned IOPS to provision, must be >= 100
+- `volume_type` - "standard", "io1", "io2", "gp2" or "gp3" ("standard" is magnetic, "io1" and "io2" are provisioned SSD, "gp2" and "gp3" are general purpose SSD)
+- `piops` - number of Provisioned IOPS to provision, must be >= 100, or between 3000 and 16000 for the "gp3" volume type
+- `throughput` - amount of throughput in MB/s for "gp3" volume types, must be between 125 and 1000 if specified
 - `existing_raid` - whether or not to assume the raid was previously assembled on existing volumes (default no)
 - `encrypted` - specify if the EBS should be encrypted
 - `kms_key_id` - the full ARN of the AWS Key Management Service (AWS KMS) master key to use when creating the encrypted volume (defaults to master key if not specified)

--- a/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/ebs_volume.rb
@@ -30,6 +30,19 @@ aws_ebs_volume 'standard_ebs_vol_with_tags' do
   action [:create, :attach]
 end
 
+aws_ebs_volume 'ssd_ebs_gp3_volume' do
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  aws_session_token node['aws_test']['session_token']
+  size 1
+  throughput 150
+  piops 3000
+  device '/dev/sdl'
+  delete_on_termination true
+  action [:create, :attach]
+  volume_type 'gp3' # test that specifying type works
+end
+
 aws_ebs_volume 'ssd_ebs_volume' do
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
@@ -58,6 +71,14 @@ aws_ebs_volume 'standard_ebs_vol' do
   aws_access_key node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
   aws_session_token node['aws_test']['session_token']
-  device '/dev/sdi'
+  device '/dev/sdk'
   action [:delete]
+end
+
+aws_ebs_volume 'ssd_ebs_gp3_volume' do
+  aws_access_key node['aws_test']['key_id']
+  aws_secret_access_key node['aws_test']['access_key']
+  aws_session_token node['aws_test']['session_token']
+  device '/dev/sdl'
+  action [:detach]
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
  - io2 and gp3 are the latest generation IOPS and general purpose SSD volumes, allow them to be managed in this cookbook: https://aws.amazon.com/ebs/volume-types/
### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>