### PR TITLE
fix(deps): update aws-sdk-core to ~> 3.126.2 to support imdsv2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -25,7 +25,7 @@ chef_version '>= 15.3'
 
 gem 'aws-sdk-cloudformation', '~> 1.21.0'
 gem 'aws-sdk-cloudwatch', '~> 1.22.0'
-gem 'aws-sdk-core', '~> 3.109.0'
+gem 'aws-sdk-core', '~> 3.126.2'
 gem 'aws-sdk-dynamodb', '~> 1.28.0'
 gem 'aws-sdk-ec2', '~> 1.214.0'
 gem 'aws-sdk-elasticloadbalancing', '~> 1.14.0'


### PR DESCRIPTION
# Description

This pull request enables support for IMDSv2 by updating the aws-sdk-core to ~> 3.126.2
This version was chosen since it includes
1. the introduction of the new class EC2Metadata (3.111.0)
1. the usage of the class in default configuration (3.125.0)
1. a bug fix related to expired tokens used in IMDS (3.126.1)

## Issues Resolved

* https://github.com/sous-chefs/aws/issues/489

## Check List

- [x] A [conventional commit](https://www.conventionalcommits.org/) message
  This triggers our CHANGELOG and release pipeline (release-please); without your change, it cannot be released.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
